### PR TITLE
fix issue when connecting to remote Firebird installation via IPv6 pr…

### DIFF
--- a/Provider/src/FirebirdSql.Data.FirebirdClient/Client/Managed/GdsConnection.cs
+++ b/Provider/src/FirebirdSql.Data.FirebirdClient/Client/Managed/GdsConnection.cs
@@ -115,7 +115,15 @@ namespace FirebirdSql.Data.Client.Managed
 				IPAddress = GetIPAddress(_dataSource, AddressFamily.InterNetwork);
 				var endPoint = new IPEndPoint(IPAddress, _portNumber);
 
-				_socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+				//Changed by Robert Dickens @RobertTheArchitect on Oct-04-2017 as
+				//Existing code bellow will fail connection when attempting to remotly connect to a
+				//Remote Firebird installation via IPv6 protocol only
+				//_socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+
+
+				//Address family being passed into Socket should reflect the AddressFamily of the IpAddress Object and not
+				//forced to InterNetwork creating a protocol conflict
+				_socket = new Socket(IPAddress.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
 
 				_socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReceiveBuffer, _packetSize);
 				_socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.SendBuffer, _packetSize);


### PR DESCRIPTION
Currently using Firebird in one of our commercial products, customer switched their network from IPv4 to IPv6 and our application broke as a result. through our investigations we found a bug in GdsConnection.cs.

when passing into the connection string either a hostname or an ipaddress the connection attempt would throw if the connection was an IPv6 address. turns out the original logic was to derive an IPAddress object from a string (Hostname or IP) and use that derived IP Address to create a Socket, however when the Socket is created it's being created for IPv4 and not the requested protocol. 

my changes bellow corrects this behavior and all of our internal units tests do pass with the changes and fails with the original nuget library 