### PR TITLE
Bugfix for gchandle leak in FbCommandInternal

### DIFF
--- a/Provider/src/FirebirdSql.Data.FirebirdClient/FirebirdClient/FbConnectionInternal.cs
+++ b/Provider/src/FirebirdSql.Data.FirebirdClient/FirebirdClient/FbConnectionInternal.cs
@@ -342,13 +342,12 @@ namespace FirebirdSql.Data.FirebirdClient
 
 		public void AddPreparedCommand(FbCommand command)
 		{
-			int position = _preparedCommands.Count;
+			int position = -1;
 			for (int i = 0; i < _preparedCommands.Count; i++)
 			{
 				if (!_preparedCommands[i].TryGetTarget(out FbCommand current))
 				{
 					position = i;
-					break;
 				}
 				else
 				{
@@ -358,7 +357,10 @@ namespace FirebirdSql.Data.FirebirdClient
 					}
 				}
 			}
-			_preparedCommands.Insert(position, new WeakReference(command));
+			if (position >= 0)
+				_preparedCommands[position].Target = command;
+			else
+				_preparedCommands.Add(new WeakReference(command));
 		}
 
 		public void RemovePreparedCommand(FbCommand command)


### PR DESCRIPTION
The handling of the _preparedCommands list is buggy. AddPreparedCommand always inserts a new WeakReference instead of reusing an existing one whose Target has been collected.

Also, if a reusable WeakReference is found, the search for a possible duplicate add doesn't work any more, as the for loop breaks out.

I found this problem in a project using v4.8.0.0 and EntityFramework and using the same FbConnection a long time. The EF doesn't Dispose the FbCommands after use. So RemovePreparedCommand is not called at once, but later on by the finalizer. In this case RemovePreparedCommand cannot find the FbCommand any more because WeakReference.Target is already null. So the _preparedCommand.RemoveAt is never called and the WeakReference without Target remains in the list. As AddPreparedTarget never reused the WeakReferences, the list grows. It reached a count > 10000000 and each GC run took seconds, even minutes to run.