### PR TITLE
Modified RollbackImplicitTransaction in FbCommand

### DIFF
--- a/Provider/src/FirebirdSql.Data.FirebirdClient/FirebirdClient/FbCommand.cs
+++ b/Provider/src/FirebirdSql.Data.FirebirdClient/FirebirdClient/FbCommand.cs
@@ -739,9 +739,12 @@ namespace FirebirdSql.Data.FirebirdClient
 				}
 				finally
 				{
-					_transaction.Dispose();
-					_transaction = null;
-					_implicitTransaction = false;
+					if (_transaction != null)
+					{
+						_transaction.Dispose();
+						_transaction = null;
+						_implicitTransaction = false;
+					}
 
 					if (_statement != null)
 					{


### PR DESCRIPTION
Sometimes _transaction can be null then _transaction.Dispose() throws an error. So wrapped this with an if - like in CommitImplicitTransaction