### PR TITLE
Added DatabaseFacade Extensions

### DIFF
--- a/Provider/src/FirebirdSql.EntityFrameworkCore.Firebird/Extensions/FbDatabaseFacadeExtensions.cs
+++ b/Provider/src/FirebirdSql.EntityFrameworkCore.Firebird/Extensions/FbDatabaseFacadeExtensions.cs
@@ -5,6 +5,8 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 
 namespace FirebirdSql.EntityFrameworkCore.Firebird.Extensions
 {
+	using System;
+
 	/// <summary>
 	///		FirebirdSQL specific extension methods for <see cref="DatabaseFacade"/>.
 	/// </summary>
@@ -28,6 +30,6 @@ namespace FirebirdSql.EntityFrameworkCore.Firebird.Extensions
 		///		True if FirebirdSQL is being used; false otherwise.
 		/// </returns>
 		public static bool IsFirebirdSql(this DatabaseFacade database)
-			=> database.ProviderName == typeof(FbOptionsExtension).GetTypeInfo().Assembly.GetName().Name;
+			=> database.ProviderName.Equals(typeof(FbOptionsExtension).GetTypeInfo().Assembly.GetName().Name, StringComparison.Ordinal);
 	}
 }

--- a/Provider/src/FirebirdSql.EntityFrameworkCore.Firebird/Extensions/FbDatabaseFacadeExtensions.cs
+++ b/Provider/src/FirebirdSql.EntityFrameworkCore.Firebird/Extensions/FbDatabaseFacadeExtensions.cs
@@ -29,7 +29,7 @@ namespace FirebirdSql.EntityFrameworkCore.Firebird.Extensions
 		/// <returns>
 		///		True if FirebirdSQL is being used; false otherwise.
 		/// </returns>
-		public static bool IsFirebirdSql(this DatabaseFacade database)
+		public static bool IsFirebird(this DatabaseFacade database)
 			=> database.ProviderName.Equals(typeof(FbOptionsExtension).GetTypeInfo().Assembly.GetName().Name, StringComparison.Ordinal);
 	}
 }

--- a/Provider/src/FirebirdSql.EntityFrameworkCore.Firebird/Extensions/FbDatabaseFacadeExtensions.cs
+++ b/Provider/src/FirebirdSql.EntityFrameworkCore.Firebird/Extensions/FbDatabaseFacadeExtensions.cs
@@ -1,0 +1,33 @@
+﻿using System.Reflection;
+using FirebirdSql.EntityFrameworkCore.Firebird.Infrastructure.Internal;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+
+namespace FirebirdSql.EntityFrameworkCore.Firebird.Extensions
+{
+	/// <summary>
+	///		FirebirdSQL specific extension methods for <see cref="DatabaseFacade"/>.
+	/// </summary>
+	public static class FbDatabaseFacadeExtensions
+	{
+		/// <summary>
+		///		<para>
+		///			Returns true if the database provider currently in use is the FirebirdSQL provider.
+		///		</para>
+		///		<para>
+		///			This method can only be used after the <see cref="DbContext" /> has been configured because
+		///			it is only then that the provider is known. This means that this method cannot be used
+		///			in <see cref="DbContext.OnConfiguring" /> because this is where application code sets the
+		///			provider to use as part of configuring the context.
+		///		</para>
+		/// </summary>
+		/// <param name="database">
+		///		The facade from <see cref="DbContext.Database" />.
+		/// </param>
+		/// <returns>
+		///		True if FirebirdSQL is being used; false otherwise.
+		/// </returns>
+		public static bool IsFirebirdSql(this DatabaseFacade database)
+			=> database.ProviderName == typeof(FbOptionsExtension).GetTypeInfo().Assembly.GetName().Name;
+	}
+}


### PR DESCRIPTION
Added a `DatabaseFacade` extension method called `IsFirebirdSql()`.
Calling `DbContext.Database.IsFirebirdSql()` will return `true` if the current database provider is FirebirdSQL, otherwise it will return false.

Example use:
```C#
protected override void OnModelCreating(ModelBuilder modelBuilder)
{
    base.OnModelCreating(modelBuilder);

    // Need to give FirebirdSQL some very special treatment
    if (!this.Database.IsFirebirdSql()) return;
	
    // Todo: Change some things for FirebirdSQL
}
```

Other implementations:
- [PostgreSQL](https://github.com/npgsql/efcore.pg/blob/dev/src/EFCore.PG/Extensions/NpgsqlDatabaseFacadeExtensions.cs)
- [SQL Server](https://github.com/dotnet/efcore/blob/master/src/EFCore.SqlServer/Extensions/SqlServerDatabaseFacadeExtensions.cs)
- [SQLite](https://github.com/dotnet/efcore/blob/master/src/EFCore.Sqlite.Core/Extensions/SqliteDatabaseFacadeExtensions.cs)