### PR TITLE
Changes for DNET-784: schema update for identity

### DIFF
--- a/Provider/src/FirebirdSql.Data.FirebirdClient/Schema/FbColumns.cs
+++ b/Provider/src/FirebirdSql.Data.FirebirdClient/Schema/FbColumns.cs
@@ -35,7 +35,7 @@ namespace FirebirdSql.Data.Schema
 			var where = new StringBuilder();
 
 			sql.Append(
-				@"SELECT
+					   @"SELECT
 					null AS TABLE_CATALOG,
 					null AS TABLE_SCHEMA,
 					rfr.rdb$relation_name AS TABLE_NAME,
@@ -64,7 +64,13 @@ namespace FirebirdSql.Data.Schema
 					null AS COLLATION_CATALOG,
 					null AS COLLATION_SCHEMA,
 					coll.rdb$collation_name AS COLLATION_NAME,
-					rfr.rdb$description AS DESCRIPTION
+					rfr.rdb$description AS DESCRIPTION");
+			if(this.MajorVersionNumber >= 3)
+			{
+				sql.Append(@",
+					rfr.rdb$identity_type as IDENTITY_TYPE");
+			}
+			sql.Append(@"
 				FROM rdb$relation_fields rfr
 				    LEFT JOIN rdb$fields fld ON rfr.rdb$field_source = fld.rdb$field_name
 				    LEFT JOIN rdb$character_sets cs ON cs.rdb$character_set_id = fld.rdb$character_set_id
@@ -117,6 +123,10 @@ namespace FirebirdSql.Data.Schema
 			schema.BeginLoadData();
 			schema.Columns.Add("IS_NULLABLE", typeof(bool));
 			schema.Columns.Add("IS_ARRAY", typeof(bool));
+			if(this.MajorVersionNumber >= 3)
+			{
+				schema.Columns.Add("IS_IDENTITY", typeof(bool));
+			}
 
 			foreach (DataRow row in schema.Rows)
 			{
@@ -175,6 +185,11 @@ namespace FirebirdSql.Data.Schema
 				{
 					row["DOMAIN_NAME"] = null;
 				}
+
+				if(this.MajorVersionNumber >= 3)
+				{
+					row["IS_IDENTITY"] = Convert.ToInt32(row["IDENTITY_TYPE"]) == 1;
+				}
 			}
 
 			schema.EndLoadData();
@@ -185,6 +200,10 @@ namespace FirebirdSql.Data.Schema
 			schema.Columns.Remove("COLUMN_ARRAY");
 			schema.Columns.Remove("FIELD_TYPE");
 			schema.Columns.Remove("CHARACTER_MAX_LENGTH");
+			if(this.MajorVersionNumber >= 3)
+			{
+				schema.Columns.Remove("IDENTITY_TYPE");
+			}
 
 			return schema;
 		}

--- a/Provider/src/FirebirdSql.Data.FirebirdClient/Schema/FbColumns.cs
+++ b/Provider/src/FirebirdSql.Data.FirebirdClient/Schema/FbColumns.cs
@@ -35,7 +35,7 @@ namespace FirebirdSql.Data.Schema
 			var where = new StringBuilder();
 
 			sql.Append(
-					   @"SELECT
+					@"SELECT
 					null AS TABLE_CATALOG,
 					null AS TABLE_SCHEMA,
 					rfr.rdb$relation_name AS TABLE_NAME,
@@ -65,7 +65,7 @@ namespace FirebirdSql.Data.Schema
 					null AS COLLATION_SCHEMA,
 					coll.rdb$collation_name AS COLLATION_NAME,
 					rfr.rdb$description AS DESCRIPTION");
-			if(this.MajorVersionNumber >= 3)
+			if (MajorVersionNumber >= 3)
 			{
 				sql.Append(@",
 					rfr.rdb$identity_type as IDENTITY_TYPE");
@@ -123,7 +123,7 @@ namespace FirebirdSql.Data.Schema
 			schema.BeginLoadData();
 			schema.Columns.Add("IS_NULLABLE", typeof(bool));
 			schema.Columns.Add("IS_ARRAY", typeof(bool));
-			if(this.MajorVersionNumber >= 3)
+			if(MajorVersionNumber >= 3)
 			{
 				schema.Columns.Add("IS_IDENTITY", typeof(bool));
 			}
@@ -186,9 +186,9 @@ namespace FirebirdSql.Data.Schema
 					row["DOMAIN_NAME"] = null;
 				}
 
-				if(this.MajorVersionNumber >= 3)
+				if (MajorVersionNumber >= 3)
 				{
-					row["IS_IDENTITY"] = Convert.ToInt32(row["IDENTITY_TYPE"]) == 1;
+					row["IS_IDENTITY"] = (row["IDENTITY_TYPE"] != DBNull.Value);
 				}
 			}
 
@@ -200,7 +200,7 @@ namespace FirebirdSql.Data.Schema
 			schema.Columns.Remove("COLUMN_ARRAY");
 			schema.Columns.Remove("FIELD_TYPE");
 			schema.Columns.Remove("CHARACTER_MAX_LENGTH");
-			if(this.MajorVersionNumber >= 3)
+			if (MajorVersionNumber >= 3)
 			{
 				schema.Columns.Remove("IDENTITY_TYPE");
 			}

--- a/Provider/src/FirebirdSql.Data.FirebirdClient/Schema/FbColumns.cs
+++ b/Provider/src/FirebirdSql.Data.FirebirdClient/Schema/FbColumns.cs
@@ -35,7 +35,7 @@ namespace FirebirdSql.Data.Schema
 			var where = new StringBuilder();
 
 			sql.Append(
-					@"SELECT
+				@"SELECT
 					null AS TABLE_CATALOG,
 					null AS TABLE_SCHEMA,
 					rfr.rdb$relation_name AS TABLE_NAME,
@@ -123,7 +123,7 @@ namespace FirebirdSql.Data.Schema
 			schema.BeginLoadData();
 			schema.Columns.Add("IS_NULLABLE", typeof(bool));
 			schema.Columns.Add("IS_ARRAY", typeof(bool));
-			if(MajorVersionNumber >= 3)
+			if (MajorVersionNumber >= 3)
 			{
 				schema.Columns.Add("IS_IDENTITY", typeof(bool));
 			}

--- a/Provider/src/FirebirdSql.Data.FirebirdClient/Schema/FbSchema.cs
+++ b/Provider/src/FirebirdSql.Data.FirebirdClient/Schema/FbSchema.cs
@@ -32,14 +32,6 @@ namespace FirebirdSql.Data.Schema
 
 	internal abstract class FbSchema
 	{
-		#region Constructors
-
-		public FbSchema()
-		{
-		}
-
-		#endregion
-
 		#region Abstract Methods
 
 		protected abstract StringBuilder GetCommandText(string[] restrictions);

--- a/Provider/src/FirebirdSql.Data.FirebirdClient/Schema/FbSchema.cs
+++ b/Provider/src/FirebirdSql.Data.FirebirdClient/Schema/FbSchema.cs
@@ -24,6 +24,7 @@ using System.Text.RegularExpressions;
 
 using FirebirdSql.Data.FirebirdClient;
 using FirebirdSql.Data.Common;
+using FirebirdSql.Data.Services;
 
 namespace FirebirdSql.Data.Schema
 {
@@ -35,7 +36,7 @@ namespace FirebirdSql.Data.Schema
 
 		public FbSchema()
 		{
-			this.MajorVersionNumber = 0;
+			MajorVersionNumber = 0;
 		}
 
 		#endregion
@@ -125,14 +126,8 @@ namespace FirebirdSql.Data.Schema
 		/// <param name="connection">an open connection, which is used to determine the version number of the connected database server</param>
 		private void SetMajorVersionNumber(FbConnection connection)
 		{
-			var versionAsString = connection?.InnerConnection?.Database?.ServerVersion ?? string.Empty;
-			if(string.IsNullOrEmpty(versionAsString))
-			{
-				return;
-			}
-
-			var fragments = versionAsString.Split('.');
-			this.MajorVersionNumber = Convert.ToInt32(fragments[0]);
+			var serverVersion = FbServerProperties.ParseServerVersion(connection.ServerVersion);
+			MajorVersionNumber = serverVersion.Major;
 		}
 		#endregion
 
@@ -165,7 +160,7 @@ namespace FirebirdSql.Data.Schema
 		/// <summary>
 		/// The major version of the connected Firebird server
 		/// </summary>
-		protected int MajorVersionNumber { get; set; }
+		protected int MajorVersionNumber { get; private set; }
 		#endregion
 	}
 }

--- a/Provider/src/FirebirdSql.Data.FirebirdClient/Schema/FbSchema.cs
+++ b/Provider/src/FirebirdSql.Data.FirebirdClient/Schema/FbSchema.cs
@@ -35,6 +35,7 @@ namespace FirebirdSql.Data.Schema
 
 		public FbSchema()
 		{
+			this.MajorVersionNumber = 0;
 		}
 
 		#endregion
@@ -74,6 +75,7 @@ namespace FirebirdSql.Data.Schema
 
 		protected FbCommand BuildCommand(FbConnection connection, string collectionName, string[] restrictions)
 		{
+			SetMajorVersionNumber(connection);
 			var filter = string.Format("CollectionName='{0}'", collectionName);
 			var builder = GetCommandText(restrictions);
 			var restriction = connection.GetSchema(DbMetaDataCollectionNames.Restrictions).Select(filter);
@@ -103,6 +105,7 @@ namespace FirebirdSql.Data.Schema
 			return command;
 		}
 
+
 		protected virtual DataTable ProcessResult(DataTable schema)
 		{
 			return schema;
@@ -114,6 +117,25 @@ namespace FirebirdSql.Data.Schema
 		}
 
 		#endregion
+
+		#region Private Methods
+		/// <summary>
+		/// Determines the major version number from the Serverversion on the inner connection.
+		/// </summary>
+		/// <param name="connection">an open connection, which is used to determine the version number of the connected database server</param>
+		private void SetMajorVersionNumber(FbConnection connection)
+		{
+			var versionAsString = connection?.InnerConnection?.Database?.ServerVersion ?? string.Empty;
+			if(string.IsNullOrEmpty(versionAsString))
+			{
+				return;
+			}
+
+			var fragments = versionAsString.Split('.');
+			this.MajorVersionNumber = Convert.ToInt32(fragments[0]);
+		}
+		#endregion
+
 
 		#region Private Static Methods
 
@@ -137,6 +159,13 @@ namespace FirebirdSql.Data.Schema
 			schema.AcceptChanges();
 		}
 
+		#endregion
+
+		#region Properties
+		/// <summary>
+		/// The major version of the connected Firebird server
+		/// </summary>
+		protected int MajorVersionNumber { get; set; }
 		#endregion
 	}
 }

--- a/Provider/src/FirebirdSql.Data.FirebirdClient/Schema/FbSchema.cs
+++ b/Provider/src/FirebirdSql.Data.FirebirdClient/Schema/FbSchema.cs
@@ -36,7 +36,6 @@ namespace FirebirdSql.Data.Schema
 
 		public FbSchema()
 		{
-			MajorVersionNumber = 0;
 		}
 
 		#endregion


### PR DESCRIPTION
Added a refactoring to FbSchema so the major version number is stored in the object. This then is used to conditionally configure the schema query for the Columns schema so it obtains rdb$relation_fields.rdb$identity_type.
In the returned datatable a new column IS_IDENTITY is added, type bool, which is set to true if the identity_type field in the resultset is 1.