### PR TITLE
reading the Unicode parameter defined in the Code First mapping

### DIFF
--- a/src/FirebirdSql.EntityFrameworkCore.Firebird/Storage/Internal/FbStringTypeMapping.cs
+++ b/src/FirebirdSql.EntityFrameworkCore.Firebird/Storage/Internal/FbStringTypeMapping.cs
@@ -26,8 +26,8 @@ public class FbStringTypeMapping : StringTypeMapping
 {
 	readonly FbDbType _fbDbType;
 
-	public FbStringTypeMapping(string storeType, DbType dbType, FbDbType fbDbType, int? size = null)
-		: base(storeType, dbType, unicode: true, size: size)
+	public FbStringTypeMapping(string storeType, DbType dbType, FbDbType fbDbType, int? size = null, bool unicode = true)
+		: base(storeType, dbType, unicode: unicode, size: size)
 	{
 		_fbDbType = fbDbType;
 	}

--- a/src/FirebirdSql.EntityFrameworkCore.Firebird/Storage/Internal/FbTypeMappingSource.cs
+++ b/src/FirebirdSql.EntityFrameworkCore.Firebird/Storage/Internal/FbTypeMappingSource.cs
@@ -133,6 +133,7 @@ public class FbTypeMappingSource : RelationalTypeMappingSource
 		var clrType = mappingInfo.ClrType;
 		var storeTypeName = mappingInfo.StoreTypeName;
 		var storeTypeNameBase = mappingInfo.StoreTypeNameBase;
+		var isUnicode = mappingInfo.IsUnicode ?? true;
 
 		if (storeTypeName != null)
 		{
@@ -178,11 +179,11 @@ public class FbTypeMappingSource : RelationalTypeMappingSource
 				{
 					if (!isFixedLength)
 					{
-						return new FbStringTypeMapping($"VARCHAR({size})", DbType.String, FbDbType.VarChar, size);
+						return new FbStringTypeMapping($"VARCHAR({size})", DbType.String, FbDbType.VarChar, size, isUnicode);
 					}
 					else
 					{
-						return new FbStringTypeMapping($"CHAR({size})", DbType.StringFixedLength, FbDbType.Char, size);
+						return new FbStringTypeMapping($"CHAR({size})", DbType.StringFixedLength, FbDbType.Char, size, isUnicode);
 					}
 				}
 			}


### PR DESCRIPTION
First, I'm using Google Translate.

I am creating this PR as directed through Twitter.

I made a small change in the src/FirebirdSql.EntityFrameworkCore.Firebird/Storage/Internal/FbTypeMappingSource.cs class to detect if the code is not setting the unicode attribute, as well as I changed the src/FirebirdSql.EntityFrameworkCore.Firebird/Storage/Internal/ class FbStringTypeMapping.cs to receive the mapping value.

If the Unicode attribute is not found, the code maintains the same pattern as before. In this case the default value = true

I'm making this contribution due to the need to turn off Unicode in the company's bases, with that, I came across this ignored implementation that makes me have to rebuild the provider with each new version.