### PR TITLE
Update FbDataReader.cs GetSchemaTable

### DIFF
--- a/src/FirebirdSql.Data.FirebirdClient/Client/Managed/Version13/GdsStatement.cs
+++ b/src/FirebirdSql.Data.FirebirdClient/Client/Managed/Version13/GdsStatement.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  *    The contents of this file are subject to the Initial
  *    Developer's Public License Version 1.0 (the "License");
  *    you may not use this file except in compliance with the
@@ -131,6 +131,34 @@ internal class GdsStatement : Version12.GdsStatement
 		}
 	}
 
+	protected override object[] ReadRowObjectValues()
+	{
+		var row = new object[_fields.Count];
+		try
+		{
+			if (_fields.Count > 0)
+			{
+				var nullBytes = _database.Xdr.ReadOpaque((int)Math.Ceiling(_fields.Count / 8d));
+				var nullBits = new BitArray(nullBytes);
+				for (var i = 0; i < _fields.Count; i++)
+				{
+					if (nullBits.Get(i))
+					{
+						row[i] = null;
+					}
+					else
+					{
+						row[i] = ReadRawValue(_database.Xdr, _fields[i]);
+					}
+				}
+			}
+		}
+		catch (IOException ex)
+		{
+			throw IscException.ForIOException(ex);
+		}
+		return row;
+	}
 	protected override DbValue[] ReadRow()
 	{
 		var row = new DbValue[_fields.Count];
@@ -179,6 +207,34 @@ internal class GdsStatement : Version12.GdsStatement
 					{
 						var value = await ReadRawValueAsync(_database.Xdr, _fields[i], cancellationToken).ConfigureAwait(false);
 						row[i] = new DbValue(this, _fields[i], value);
+					}
+				}
+			}
+		}
+		catch (IOException ex)
+		{
+			throw IscException.ForIOException(ex);
+		}
+		return row;
+	}
+	protected override async ValueTask<object[]> ReadRowObjectValuesAsync(CancellationToken cancellationToken = default)
+	{
+		var row = new object[_fields.Count];
+		try
+		{
+			if (_fields.Count > 0)
+			{
+				var nullBytes = await _database.Xdr.ReadOpaqueAsync((int)Math.Ceiling(_fields.Count / 8d), cancellationToken).ConfigureAwait(false);
+				var nullBits = new BitArray(nullBytes);
+				for (var i = 0; i < _fields.Count; i++)
+				{
+					if (nullBits.Get(i))
+					{
+						row[i] = null;
+					}
+					else
+					{
+						row[i] = await ReadRawValueAsync(_database.Xdr, _fields[i], cancellationToken).ConfigureAwait(false);
 					}
 				}
 			}

--- a/src/FirebirdSql.Data.FirebirdClient/FirebirdClient/FbDataReader.cs
+++ b/src/FirebirdSql.Data.FirebirdClient/FirebirdClient/FbDataReader.cs
@@ -279,29 +279,99 @@ public sealed class FbDataReader : DbDataReader
 		}
 	}
 
-	public override DataTable GetSchemaTable()
+	private FbCommand GetSchemaCommand()
 	{
-		CheckState();
+		var command = _connection.CreateCommand();
+		command.Transaction = _command.Transaction;		// Same transaction if exists
+		command.FetchSize = 32767;        // Singlerequest all Fields, single Transaction
 
-		if (_schemaTable != null)
+		// all relations, which used
+		foreach (var relation in Enumerable.Range(0, _fields.Count).Where(f => !string.IsNullOrEmpty(_fields[f].Relation)).Select(f => _fields[f].Relation).Distinct())
 		{
-			return _schemaTable;
+			if (relation != string.Empty)
+			{
+				var par = command.CreateParameter();
+				par.DbType = DbType.String;
+				par.Value = relation;
+				command.Parameters.Add(par);
+			}
 		}
+		if (command.Parameters.Count > 0)
+		{
+			command.CommandText = string.Format(GetSchemaCommandSingleRequest(), string.Join(", ", Enumerable.Range(0, command.Parameters.Count).Select(p => "?")));
+			return command;
+		}
+		command.Dispose();
+		return null;
+	}
 
+	private async Task<DataTable> GetFieldsSchemaAsync(CancellationToken cancellationToken = default)
+	{
+		if (GetSchemaCommand() is FbCommand schemaCommand)
+		{
+			using (var reader = await schemaCommand.ExecuteReaderAsync(CommandBehavior.Default, cancellationToken).ConfigureAwait(false))
+			{
+				var fieldsSchema = new DataTable();
+				fieldsSchema.Columns.AddRange(Enumerable.Range(0, reader.FieldCount).Select(i =>
+					 new DataColumn(reader.GetName(i), reader.GetFieldType(i))
+					 {
+						 AllowDBNull = true
+					 }).ToArray());
+				var values = new object[reader.FieldCount];
+				fieldsSchema.BeginLoadData();
+				while (await reader.ReadAsync().ConfigureAwait(false))
+				{
+					reader.GetValues(values);
+					fieldsSchema.Rows.Add(values);
+				}
+				fieldsSchema.DefaultView.Sort = "base_table, base_field";
+				return fieldsSchema;
+			}
+		}
+		return null;
+	}
+
+	private DataTable GetFieldsSchema()
+	{
+		if (GetSchemaCommand() is FbCommand schemaCommand)
+		{
+			using (schemaCommand)
+			{
+				using (var reader = schemaCommand.ExecuteReader())
+				{
+					var fieldsSchema = new DataTable();
+					fieldsSchema.Columns.AddRange(Enumerable.Range(0, reader.FieldCount).Select(i =>
+						 new DataColumn(reader.GetName(i), reader.GetFieldType(i))
+						 {
+							 AllowDBNull = true
+						 }).ToArray());
+					var values = new object[reader.FieldCount];
+					fieldsSchema.BeginLoadData();
+					while (reader.Read())
+					{
+						reader.GetValues(values);
+						fieldsSchema.Rows.Add(values);
+					}
+					fieldsSchema.DefaultView.Sort = "base_table, base_field";
+					return fieldsSchema;
+				}
+			}
+		}
+		return null;
+	}
+
+	private DataTable LoadSchemaTable(DataTable fieldsTable)
+	{
 		DataRow schemaRow = null;
-		var tableCount = 0;
-		var currentTable = string.Empty;
+
+		// no of relations including calculated columns with no relation
+		var singleTable = Enumerable.Range(0, _fields.Count).Select(f => _fields[f].Relation).Any(r => string.IsNullOrEmpty(r)) == false &&
+			Enumerable.Range(0, _fields.Count).Select(f => _fields[f].Relation).Distinct().Count() == 1;
 
 		_schemaTable = GetSchemaTableStructure();
 
-		/* Prepare statement for schema fields information	*/
-		var schemaCmd = new FbCommand(GetSchemaCommandText(), _command.Connection, _command.Connection.InnerConnection.ActiveTransaction);
 		try
 		{
-			schemaCmd.Parameters.Add("@TABLE_NAME", FbDbType.Char, 31);
-			schemaCmd.Parameters.Add("@COLUMN_NAME", FbDbType.Char, 31);
-			schemaCmd.Prepare();
-
 			_schemaTable.BeginLoadData();
 
 			for (var i = 0; i < _fields.Count; i++)
@@ -312,29 +382,19 @@ public sealed class FbDataReader : DbDataReader
 				var precision = 0;
 				var isExpression = false;
 
-				/* Get Schema data for the field	*/
-				schemaCmd.Parameters[0].Value = _fields[i].Relation;
-				schemaCmd.Parameters[1].Value = _fields[i].Name;
-
-				var reader = schemaCmd.ExecuteReader(CommandBehavior.Default);
-				try
+				if (fieldsTable != null)    // relation exists in result
 				{
-					if (reader.Read())
+					var rows = fieldsTable.DefaultView.FindRows(new object[] { _fields[i].Relation, _fields[i].Name });
+					if (rows.Length > 0)
 					{
-						isReadOnly = (IsReadOnly(reader) || IsExpression(reader)) ? true : false;
-						isKeyColumn = (reader.GetInt32(2) == 1) ? true : false;
-						isUnique = (reader.GetInt32(3) == 1) ? true : false;
-						precision = reader.IsDBNull(4) ? -1 : reader.GetInt32(4);
-						isExpression = IsExpression(reader);
+						isReadOnly = !TypeHelper.IsDBNull(rows[0][0]) || !TypeHelper.IsDBNull(rows[0][1]);
+						isKeyColumn = Convert.ToInt32(rows[0][2]) == 1;
+						isUnique = Convert.ToInt32(rows[0][3]) == 1;
+						precision = TypeHelper.IsDBNull(rows[0][4]) ? -1 : Convert.ToInt32(rows[0][4]);
+
+						// Same as readonly
+						isExpression = !TypeHelper.IsDBNull(rows[0][0]) || !TypeHelper.IsDBNull(rows[0][1]);
 					}
-				}
-				finally
-				{
-#if NET48 || NETSTANDARD2_0
-					reader.Dispose();
-#else
-					reader.Dispose();
-#endif
 				}
 
 				/* Create new row for the Schema Table	*/
@@ -368,39 +428,41 @@ public sealed class FbDataReader : DbDataReader
 				schemaRow["BaseTableName"] = _fields[i].Relation;
 				schemaRow["BaseColumnName"] = _fields[i].Name;
 
+				if (!singleTable)	// more than 1 or calculated columns
+				{
+					schemaRow["IsKey"] = false;
+					schemaRow["IsUnique"] = false;
+				}
+
 				_schemaTable.Rows.Add(schemaRow);
-
-				if (!string.IsNullOrEmpty(_fields[i].Relation) && currentTable != _fields[i].Relation)
-				{
-					tableCount++;
-					currentTable = _fields[i].Relation;
-				}
-
-				schemaCmd.Close();
 			}
-
-			if (tableCount > 1)
-			{
-				foreach (DataRow row in _schemaTable.Rows)
-				{
-					row["IsKey"] = false;
-					row["IsUnique"] = false;
-				}
-			}
-
 			_schemaTable.EndLoadData();
 		}
 		finally
 		{
 #if NET48 || NETSTANDARD2_0
-			schemaCmd.Dispose();
+			//schemaCmd.Dispose();
 #else
-			schemaCmd.Dispose();
+			//schemaCmd.Dispose();
 #endif
+			fieldsTable?.Dispose();
 		}
 
 		return _schemaTable;
 	}
+
+	public override DataTable GetSchemaTable()
+	{
+		CheckState();
+
+		if (_schemaTable != null)
+		{
+			return _schemaTable;
+		}
+
+		return LoadSchemaTable(GetFieldsSchema());
+	}
+
 #if NET48 || NETSTANDARD2_0 || NETSTANDARD2_1
 	public async Task<DataTable> GetSchemaTableAsync(CancellationToken cancellationToken = default)
 #else
@@ -414,121 +476,10 @@ public sealed class FbDataReader : DbDataReader
 			return _schemaTable;
 		}
 
-		DataRow schemaRow = null;
-		var tableCount = 0;
-		var currentTable = string.Empty;
-
-		_schemaTable = GetSchemaTableStructure();
-
-		/* Prepare statement for schema fields information	*/
-		var schemaCmd = new FbCommand(GetSchemaCommandText(), _command.Connection, _command.Connection.InnerConnection.ActiveTransaction);
-		try
-		{
-			schemaCmd.Parameters.Add("@TABLE_NAME", FbDbType.Char, 31);
-			schemaCmd.Parameters.Add("@COLUMN_NAME", FbDbType.Char, 31);
-			await schemaCmd.PrepareAsync(cancellationToken).ConfigureAwait(false);
-
-			_schemaTable.BeginLoadData();
-
-			for (var i = 0; i < _fields.Count; i++)
-			{
-				var isKeyColumn = false;
-				var isUnique = false;
-				var isReadOnly = false;
-				var precision = 0;
-				var isExpression = false;
-
-				/* Get Schema data for the field	*/
-				schemaCmd.Parameters[0].Value = _fields[i].Relation;
-				schemaCmd.Parameters[1].Value = _fields[i].Name;
-
-				var reader = await schemaCmd.ExecuteReaderAsync(CommandBehavior.Default, cancellationToken).ConfigureAwait(false);
-				try
-				{
-					if (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
-					{
-						isReadOnly = IsReadOnly(reader) || IsExpression(reader);
-						isKeyColumn = reader.GetInt32(2) == 1;
-						isUnique = reader.GetInt32(3) == 1;
-						precision = reader.IsDBNull(4) ? -1 : reader.GetInt32(4);
-						isExpression = IsExpression(reader);
-					}
-				}
-				finally
-				{
-#if NET48 || NETSTANDARD2_0
-					reader.Dispose();
-#else
-					await reader.DisposeAsync().ConfigureAwait(false);
-#endif
-				}
-
-				/* Create new row for the Schema Table	*/
-				schemaRow = _schemaTable.NewRow();
-
-				schemaRow["ColumnName"] = GetName(i);
-				schemaRow["ColumnOrdinal"] = i;
-				schemaRow["ColumnSize"] = _fields[i].GetSize();
-				if (_fields[i].IsDecimal())
-				{
-					schemaRow["NumericPrecision"] = schemaRow["ColumnSize"];
-					if (precision > 0)
-					{
-						schemaRow["NumericPrecision"] = precision;
-					}
-					schemaRow["NumericScale"] = _fields[i].NumericScale * (-1);
-				}
-				schemaRow["DataType"] = GetFieldType(i);
-				schemaRow["ProviderType"] = GetProviderType(i);
-				schemaRow["IsLong"] = _fields[i].IsLong();
-				schemaRow["AllowDBNull"] = _fields[i].AllowDBNull();
-				schemaRow["IsRowVersion"] = false;
-				schemaRow["IsAutoIncrement"] = false;
-				schemaRow["IsReadOnly"] = isReadOnly;
-				schemaRow["IsKey"] = isKeyColumn;
-				schemaRow["IsUnique"] = isUnique;
-				schemaRow["IsAliased"] = _fields[i].IsAliased();
-				schemaRow["IsExpression"] = isExpression;
-				schemaRow["BaseSchemaName"] = DBNull.Value;
-				schemaRow["BaseCatalogName"] = DBNull.Value;
-				schemaRow["BaseTableName"] = _fields[i].Relation;
-				schemaRow["BaseColumnName"] = _fields[i].Name;
-
-				_schemaTable.Rows.Add(schemaRow);
-
-				if (!string.IsNullOrEmpty(_fields[i].Relation) && currentTable != _fields[i].Relation)
-				{
-					tableCount++;
-					currentTable = _fields[i].Relation;
-				}
-
-				await schemaCmd.CloseAsync().ConfigureAwait(false);
-			}
-
-			if (tableCount > 1)
-			{
-				foreach (DataRow row in _schemaTable.Rows)
-				{
-					row["IsKey"] = false;
-					row["IsUnique"] = false;
-				}
-			}
-
-			_schemaTable.EndLoadData();
-		}
-		finally
-		{
-#if NET48 || NETSTANDARD2_0
-			schemaCmd.Dispose();
-#else
-			await schemaCmd.DisposeAsync().ConfigureAwait(false);
-#endif
-		}
-
-		return _schemaTable;
+		return LoadSchemaTable(await GetFieldsSchemaAsync(cancellationToken).ConfigureAwait(false));
 	}
 
-	public override int GetOrdinal(string name)
+ 	public override int GetOrdinal(string name)
 	{
 		CheckState();
 
@@ -1130,7 +1081,7 @@ public sealed class FbDataReader : DbDataReader
 		return schema;
 	}
 
-	private static string GetSchemaCommandText()
+	private static string GetSchemaCommandSingleRequest()
 	{
 		const string sql =
 			@"SELECT
@@ -1148,12 +1099,17 @@ public sealed class FbDataReader : DbDataReader
 					WHERE rel.rdb$constraint_type = 'UNIQUE'
 					  AND rel.rdb$relation_name = rfr.rdb$relation_name
 					  AND seg.rdb$field_name = rfr.rdb$field_name) AS unique_key,
-					fld.rdb$field_precision AS numeric_precision
+					fld.rdb$field_precision AS numeric_precision,
+
+                    rfr.rdb$relation_name   base_table,
+                    rfr.rdb$field_name      base_field
+
 				  FROM rdb$relation_fields rfr
 					INNER JOIN rdb$fields fld ON rfr.rdb$field_source = fld.rdb$field_name
-				  WHERE rfr.rdb$relation_name = ?
-					AND rfr.rdb$field_name = ?
-				  ORDER BY rfr.rdb$relation_name, rfr.rdb$field_position";
+
+					WHERE rfr.rdb$relation_name in ({0})";
+		// isn't necessary
+		//ORDER BY rfr.rdb$relation_name, rfr.rdb$field_position";
 
 		return sql;
 	}

--- a/src/FirebirdSql.Data.FirebirdClient/FirebirdClient/FbDataReader.cs
+++ b/src/FirebirdSql.Data.FirebirdClient/FirebirdClient/FbDataReader.cs
@@ -547,12 +547,12 @@ public sealed class FbDataReader : DbDataReader
 				}
 				if (nullableUnderlying == typeof(bool))
 				{
-					return GetFieldValue<bool>(i);
+					return _row[i].GetBoolean();
 				}
 			}
 			if (type == typeof(bool))
 			{
-				return GetFieldValue<bool>(i);
+				return _row[i].GetBoolean(); 
 			}
 		}
 
@@ -561,112 +561,75 @@ public sealed class FbDataReader : DbDataReader
 
 	public override int GetValues(object[] values)
 	{
+		CheckState();
+		CheckPosition();
+
 		var count = Math.Min(_fields.Count, values.Length);
-		for (var i = 0; i < count; i++)
+		try
 		{
-			values[i] = GetValue(i);
+			for (var i = 0; i < count; i++)
+			{
+				if (_command.ExpectedColumnTypes != null)
+				{
+					var type = _command.ExpectedColumnTypes.ElementAtOrDefault(i);
+					var nullableUnderlying = Nullable.GetUnderlyingType(type);
+					if (nullableUnderlying != null)
+					{
+						if (IsDBNull(i))
+						{
+							values[i] = null;
+							continue;
+						}
+						if (nullableUnderlying == typeof(bool))
+						{
+							values[i] = _row[i].GetBoolean();
+							continue;
+						}
+					}
+					if (type == typeof(bool))
+					{
+						values[i] = _row[i].GetBoolean();
+						continue;
+					}
+				}
+				values[i] = _row[i].GetValue();
+			}
+			return count;
 		}
-		return count;
+		catch (IscException ex)
+		{
+			throw FbException.Create(ex);
+		}
 	}
 
 	public override T GetFieldValue<T>(int i)
 	{
-		CheckState();
-		CheckPosition();
-		CheckIndex(i);
-
-		var type = typeof(T);
-		type = Nullable.GetUnderlyingType(type) ?? type;
+		var type = Nullable.GetUnderlyingType(typeof(T)) ?? typeof(T);
 		try
 		{
-			if (type == typeof(bool))
-			{
-				return (T)(object)_row[i].GetBoolean();
-			}
-			else if (type == typeof(byte))
-			{
-				return (T)(object)_row[i].GetByte();
-			}
-			else if (type == typeof(char))
-			{
-				return (T)(object)_row[i].GetChar();
-			}
-			else if (type == typeof(Guid))
-			{
-				return (T)(object)_row[i].GetGuid();
-			}
-			else if (type == typeof(short))
-			{
-				return (T)(object)_row[i].GetInt16();
-			}
-			else if (type == typeof(int))
-			{
-				return (T)(object)_row[i].GetInt32();
-			}
-			else if (type == typeof(long))
-			{
-				return (T)(object)_row[i].GetInt64();
-			}
-			else if (type == typeof(float))
-			{
-				return (T)(object)_row[i].GetFloat();
-			}
-			else if (type == typeof(double))
-			{
-				return (T)(object)_row[i].GetDouble();
-			}
-			else if (type == typeof(string))
-			{
-				return (T)(object)_row[i].GetString();
-			}
-			else if (type == typeof(decimal))
-			{
-				return (T)(object)_row[i].GetDecimal();
-			}
-			else if (type == typeof(DateTime))
-			{
-				return (T)(object)_row[i].GetDateTime();
-			}
-			else if (type == typeof(TimeSpan))
-			{
-				return (T)(object)_row[i].GetTimeSpan();
-			}
-			else if (type == typeof(byte[]))
-			{
-				return (T)(object)_row[i].GetBinary();
-			}
-			else if (type == typeof(FbDecFloat))
-			{
-				return (T)(object)_row[i].GetDecFloat();
-			}
-			else if (type == typeof(BigInteger))
-			{
-				return (T)(object)_row[i].GetInt128();
-			}
-			else if (type == typeof(FbZonedDateTime))
-			{
-				return (T)(object)_row[i].GetZonedDateTime();
-			}
-			else if (type == typeof(FbZonedTime))
-			{
-				return (T)(object)_row[i].GetZonedTime();
-			}
+			return type == typeof(bool) ? (T)(object)_row[i].GetBoolean()
+					: type == typeof(byte) ? (T)(object)_row[i].GetByte()
+					: type == typeof(char) ? (T)(object)_row[i].GetChar()
+					: type == typeof(short) ? (T)(object)_row[i].GetInt16()
+					: type == typeof(int) ? (T)(object)_row[i].GetInt32()
+					: type == typeof(long) ? (T)(object)_row[i].GetInt64()
+					: type == typeof(float) ? (T)(object)_row[i].GetFloat()
+					: type == typeof(double) ? (T)(object)_row[i].GetDouble()
+					: type == typeof(string) ? (T)(object)_row[i].GetString()
+					: type == typeof(decimal) ? (T)(object)_row[i].GetDecimal()
+					: type == typeof(DateTime) ? (T)(object)_row[i].GetDateTime()
+					: type == typeof(TimeSpan) ? (T)(object)_row[i].GetTimeSpan()
+					: type == typeof(byte[]) ? (T)(object)_row[i].GetBinary()
+					: type == typeof(FbDecFloat) ? (T)(object)_row[i].GetDecFloat()
+					: type == typeof(BigInteger) ? (T)(object)_row[i].GetInt128()
+					: type == typeof(FbZonedDateTime) ? (T)(object)_row[i].GetZonedDateTime()
 #if NET6_0_OR_GREATER
-			else if (type == typeof(DateOnly))
-			{
-				return (T)(object)DateOnly.FromDateTime(_row[i].GetDateTime());
-			}
+					: type == typeof(FbZonedDateTime) ? (T)(object)_row[i].GetZonedDateTime()
+					: type == typeof(DateOnly) ? (T)(object)DateOnly.FromDateTime(_row[i].GetDateTime())
+					: type == typeof(TimeOnly) ? (T)(object)TimeOnly.FromTimeSpan(_row[i].GetTimeSpan())
 #endif
-#if NET6_0_OR_GREATER
-			else if (type == typeof(TimeOnly))
-			{
-				return (T)(object)TimeOnly.FromTimeSpan(_row[i].GetTimeSpan());
-			}
-#endif
-			else
-			{
-				return (T)_row[i].GetValue();
-			}
+					: (T)_row[i].GetValue()
+					;
 		}
 		catch (IscException ex)
 		{
@@ -680,98 +643,32 @@ public sealed class FbDataReader : DbDataReader
 		CheckPosition();
 		CheckIndex(i);
 
-		var type = typeof(T);
-		type = Nullable.GetUnderlyingType(type) ?? type;
+		var type = Nullable.GetUnderlyingType(typeof(T)) ?? typeof(T);
 		try
 		{
-			if (type == typeof(bool))
-			{
-				return (T)(object)_row[i].GetBoolean();
-			}
-			else if (type == typeof(byte))
-			{
-				return (T)(object)_row[i].GetByte();
-			}
-			else if (type == typeof(char))
-			{
-				return (T)(object)_row[i].GetChar();
-			}
-			else if (type == typeof(Guid))
-			{
-				return (T)(object)_row[i].GetGuid();
-			}
-			else if (type == typeof(short))
-			{
-				return (T)(object)_row[i].GetInt16();
-			}
-			else if (type == typeof(int))
-			{
-				return (T)(object)_row[i].GetInt32();
-			}
-			else if (type == typeof(long))
-			{
-				return (T)(object)_row[i].GetInt64();
-			}
-			else if (type == typeof(float))
-			{
-				return (T)(object)_row[i].GetFloat();
-			}
-			else if (type == typeof(double))
-			{
-				return (T)(object)_row[i].GetDouble();
-			}
-			else if (type == typeof(string))
-			{
-				return (T)(object)await _row[i].GetStringAsync(cancellationToken).ConfigureAwait(false);
-			}
-			else if (type == typeof(decimal))
-			{
-				return (T)(object)_row[i].GetDecimal();
-			}
-			else if (type == typeof(DateTime))
-			{
-				return (T)(object)_row[i].GetDateTime();
-			}
-			else if (type == typeof(TimeSpan))
-			{
-				return (T)(object)_row[i].GetTimeSpan();
-			}
-			else if (type == typeof(byte[]))
-			{
-				return (T)(object)await _row[i].GetBinaryAsync().ConfigureAwait(false);
-			}
-			else if (type == typeof(FbDecFloat))
-			{
-				return (T)(object)_row[i].GetDecFloat();
-			}
-			else if (type == typeof(BigInteger))
-			{
-				return (T)(object)_row[i].GetInt128();
-			}
-			else if (type == typeof(FbZonedDateTime))
-			{
-				return (T)(object)_row[i].GetZonedDateTime();
-			}
-			else if (type == typeof(FbZonedTime))
-			{
-				return (T)(object)_row[i].GetZonedTime();
-			}
+			return type == typeof(bool) ? (T)(object)_row[i].GetBoolean()
+					: type == typeof(byte) ? (T)(object)_row[i].GetByte()
+					: type == typeof(char) ? (T)(object)_row[i].GetChar()
+					: type == typeof(short) ? (T)(object)_row[i].GetInt16()
+					: type == typeof(int) ? (T)(object)_row[i].GetInt32()
+					: type == typeof(long) ? (T)(object)_row[i].GetInt64()
+					: type == typeof(float) ? (T)(object)_row[i].GetFloat()
+					: type == typeof(double) ? (T)(object)_row[i].GetDouble()
+					: type == typeof(string) ? (T)(object)await _row[i].GetStringAsync(cancellationToken).ConfigureAwait(false)
+					: type == typeof(decimal) ? (T)(object)_row[i].GetDecimal()
+					: type == typeof(DateTime) ? (T)(object)_row[i].GetDateTime()
+					: type == typeof(TimeSpan) ? (T)(object)_row[i].GetTimeSpan()
+					: type == typeof(byte[]) ? (T)(object)await _row[i].GetBinaryAsync(cancellationToken).ConfigureAwait(false)
+					: type == typeof(FbDecFloat) ? (T)(object)_row[i].GetDecFloat()
+					: type == typeof(BigInteger) ? (T)(object)_row[i].GetInt128()
+					: type == typeof(FbZonedDateTime) ? (T)(object)_row[i].GetZonedDateTime()
 #if NET6_0_OR_GREATER
-			else if (type == typeof(DateOnly))
-			{
-				return (T)(object)DateOnly.FromDateTime(_row[i].GetDateTime());
-			}
+					: type == typeof(FbZonedDateTime) ? (T)(object)_row[i].GetZonedDateTime()
+					: type == typeof(DateOnly) ? (T)(object)DateOnly.FromDateTime(_row[i].GetDateTime())
+					: type == typeof(TimeOnly) ? (T)(object)TimeOnly.FromTimeSpan(_row[i].GetTimeSpan())
 #endif
-#if NET6_0_OR_GREATER
-			else if (type == typeof(TimeOnly))
-			{
-				return (T)(object)TimeOnly.FromTimeSpan(_row[i].GetTimeSpan());
-			}
-#endif
-			else
-			{
-				return (T)await _row[i].GetValueAsync().ConfigureAwait(false);
-			}
+					: (T)await _row[i].GetValueAsync(cancellationToken).ConfigureAwait(false)
+					;
 		}
 		catch (IscException ex)
 		{


### PR DESCRIPTION
Modified GetSchemaTable/Async to a single request to the FB-Server. At the moment, in a loop is made a request for each field. If no transaction is specified, additional internal transaction is created. So if you have N fields in the result, you made N requests to the server, perhaps including many transactions. If a query is made with derived tables, the relation of field get empty, but the request is done. So you can be faster with a single call and single transaction to the server and load all fields of involved relations. The FetchSize can increase to the max to get all at once. The final build for the SchemaTable can be done within one loop. Also GetSchemaTable/GetSchemaTableAsync can share the code for building the schema. And real, the GetSchemaTable for 100 columns is less then 10ms.
Also the modifikation of "IsKey/IsUnique" depends on the count of relations. But if you have no relation in a field _or_ more then one relation is used, the IsKey/IsUnique should be false.
Furthermore, if you have not all primary or unique fields of the relation in the result, IsKey/IsUnique should also be false. This can now be checked without additional requests.