### PR TITLE
Use the correct charset when writing values to the database

### DIFF
--- a/src/FirebirdSql.Data.FirebirdClient/Common/Charset.cs
+++ b/src/FirebirdSql.Data.FirebirdClient/Common/Charset.cs
@@ -19,6 +19,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using FbCharsetEnum = FirebirdSql.Data.FirebirdClient.FbCharset;
 
 namespace FirebirdSql.Data.Common;
 
@@ -29,12 +30,14 @@ internal sealed class Charset
 
 	private readonly static Dictionary<int, Charset> charsetsById;
 	private readonly static Dictionary<string, Charset> charsetsByName;
+	private readonly static Dictionary<FbCharsetEnum, Charset> charsetsByFbCharset;
 
 	static Charset()
 	{
 		var charsets = GetSupportedCharsets();
 		charsetsById = charsets.ToDictionary(x => x.Identifier);
 		charsetsByName = charsets.ToDictionary(x => x.Name, StringComparer.CurrentCultureIgnoreCase);
+		charsetsByFbCharset = charsets.Where(x => x.FbCharset != null).ToDictionary(x => x.FbCharset.Value);
 	}
 
 	public static Charset DefaultCharset => charsetsByName[None];
@@ -43,43 +46,45 @@ internal sealed class Charset
 
 	public static bool TryGetByName(string name, out Charset charset) => charsetsByName.TryGetValue(name, out charset);
 
+	public static bool TryGetByType(FbCharsetEnum fbCharset, out Charset charset) => charsetsByFbCharset.TryGetValue(fbCharset, out charset);
+
 	private static List<Charset> GetSupportedCharsets()
 	{
 		var charsets = new List<Charset>();
 
-		charsets.Add(new Charset(0, None, 1, None));
-		charsets.Add(new Charset(1, Octets, 1, Octets));
-		charsets.Add(new Charset(2, "ASCII", 1, "ascii"));
-		charsets.Add(new Charset(3, "UNICODE_FSS", 3, "UTF-8"));
-		charsets.Add(new Charset(4, "UTF8", 4, "UTF-8"));
+		charsets.Add(new Charset(0, None, 1, None, FbCharsetEnum.None));
+		charsets.Add(new Charset(1, Octets, 1, Octets, FbCharsetEnum.Octets));
+		charsets.Add(new Charset(2, "ASCII", 1, "ascii", FbCharsetEnum.Ascii));
+		charsets.Add(new Charset(3, "UNICODE_FSS", 3, "UTF-8")); //Don't set FbCharSet, UTF8 is preferred above UNICODE_FSS
+		charsets.Add(new Charset(4, "UTF8", 4, "UTF-8", FbCharsetEnum.Utf8));
 
-		TryAddCharset(charsets, () => new Charset(5, "SJIS_0208", 2, "shift_jis"));
-		TryAddCharset(charsets, () => new Charset(6, "EUCJ_0208", 2, "euc-jp"));
-		TryAddCharset(charsets, () => new Charset(7, "ISO2022-JP", 2, "iso-2022-jp"));
-		TryAddCharset(charsets, () => new Charset(10, "DOS437", 1, "IBM437"));
-		TryAddCharset(charsets, () => new Charset(11, "DOS850", 1, "ibm850"));
-		TryAddCharset(charsets, () => new Charset(12, "DOS865", 1, "IBM865"));
-		TryAddCharset(charsets, () => new Charset(13, "DOS860", 1, "IBM860"));
-		TryAddCharset(charsets, () => new Charset(14, "DOS863", 1, "IBM863"));
-		TryAddCharset(charsets, () => new Charset(21, "ISO8859_1", 1, "iso-8859-1"));
-		TryAddCharset(charsets, () => new Charset(22, "ISO8859_2", 1, "iso-8859-2"));
-		TryAddCharset(charsets, () => new Charset(44, "KSC_5601", 2, "ks_c_5601-1987"));
-		TryAddCharset(charsets, () => new Charset(47, "DOS861", 1, "ibm861"));
-		TryAddCharset(charsets, () => new Charset(51, "WIN1250", 1, "windows-1250"));
-		TryAddCharset(charsets, () => new Charset(52, "WIN1251", 1, "windows-1251"));
-		TryAddCharset(charsets, () => new Charset(53, "WIN1252", 1, "windows-1252"));
-		TryAddCharset(charsets, () => new Charset(54, "WIN1253", 1, "windows-1253"));
-		TryAddCharset(charsets, () => new Charset(55, "WIN1254", 1, "windows-1254"));
-		TryAddCharset(charsets, () => new Charset(56, "BIG_5", 2, "big5"));
-		TryAddCharset(charsets, () => new Charset(57, "GB_2312", 2, "gb2312"));
-		TryAddCharset(charsets, () => new Charset(58, "WIN1255", 1, "windows-1255"));
-		TryAddCharset(charsets, () => new Charset(59, "WIN1256", 1, "windows-1256"));
-		TryAddCharset(charsets, () => new Charset(60, "WIN1257", 1, "windows-1257"));
+		TryAddCharset(charsets, () => new Charset(5, "SJIS_0208", 2, "shift_jis", FbCharsetEnum.ShiftJis0208));
+		TryAddCharset(charsets, () => new Charset(6, "EUCJ_0208", 2, "euc-jp", FbCharsetEnum.EucJapanese0208));
+		TryAddCharset(charsets, () => new Charset(7, "ISO2022-JP", 2, "iso-2022-jp", FbCharsetEnum.Iso2022Japanese));
+		TryAddCharset(charsets, () => new Charset(10, "DOS437", 1, "IBM437", FbCharsetEnum.Dos437));
+		TryAddCharset(charsets, () => new Charset(11, "DOS850", 1, "ibm850", FbCharsetEnum.Dos850));
+		TryAddCharset(charsets, () => new Charset(12, "DOS865", 1, "IBM865", FbCharsetEnum.Dos865));
+		TryAddCharset(charsets, () => new Charset(13, "DOS860", 1, "IBM860", FbCharsetEnum.Dos860));
+		TryAddCharset(charsets, () => new Charset(14, "DOS863", 1, "IBM863", FbCharsetEnum.Dos863));
+		TryAddCharset(charsets, () => new Charset(21, "ISO8859_1", 1, "iso-8859-1", FbCharsetEnum.Iso8859_1));
+		TryAddCharset(charsets, () => new Charset(22, "ISO8859_2", 1, "iso-8859-2", FbCharsetEnum.Iso8859_2));
+		TryAddCharset(charsets, () => new Charset(44, "KSC_5601", 2, "ks_c_5601-1987", FbCharsetEnum.Ksc5601));
+		TryAddCharset(charsets, () => new Charset(47, "DOS861", 1, "ibm861", FbCharsetEnum.Dos861));
+		TryAddCharset(charsets, () => new Charset(51, "WIN1250", 1, "windows-1250", FbCharsetEnum.Windows1250));
+		TryAddCharset(charsets, () => new Charset(52, "WIN1251", 1, "windows-1251", FbCharsetEnum.Windows1251));
+		TryAddCharset(charsets, () => new Charset(53, "WIN1252", 1, "windows-1252", FbCharsetEnum.Windows1252));
+		TryAddCharset(charsets, () => new Charset(54, "WIN1253", 1, "windows-1253", FbCharsetEnum.Windows1253));
+		TryAddCharset(charsets, () => new Charset(55, "WIN1254", 1, "windows-1254", FbCharsetEnum.Windows1254));
+		TryAddCharset(charsets, () => new Charset(56, "BIG_5", 2, "big5", FbCharsetEnum.Big5));
+		TryAddCharset(charsets, () => new Charset(57, "GB_2312", 2, "gb2312", FbCharsetEnum.Gb2312));
+		TryAddCharset(charsets, () => new Charset(58, "WIN1255", 1, "windows-1255", FbCharsetEnum.Windows1255));
+		TryAddCharset(charsets, () => new Charset(59, "WIN1256", 1, "windows-1256", FbCharsetEnum.Windows1256));
+		TryAddCharset(charsets, () => new Charset(60, "WIN1257", 1, "windows-1257", FbCharsetEnum.Windows1257));
 		//TryAddCharset(charsets, () => new Charset(61, "UTF16", 4, "utf-16"));
 		//TryAddCharset(charsets, () => new Charset(62, "UTF32", 4, "utf-32"));
-		TryAddCharset(charsets, () => new Charset(63, "KOI8R", 2, "koi8-r"));
-		TryAddCharset(charsets, () => new Charset(64, "KOI8U", 2, "koi8-u"));
-		TryAddCharset(charsets, () => new Charset(65, "TIS620", 1, "tis-620"));
+		TryAddCharset(charsets, () => new Charset(63, "KOI8R", 2, "koi8-r", FbCharsetEnum.Koi8R));
+		TryAddCharset(charsets, () => new Charset(64, "KOI8U", 2, "koi8-u", FbCharsetEnum.Koi8U));
+		TryAddCharset(charsets, () => new Charset(65, "TIS620", 1, "tis-620", FbCharsetEnum.TIS620));
 
 		return charsets;
 	}
@@ -101,8 +106,9 @@ internal sealed class Charset
 	public Encoding Encoding { get; }
 	public bool IsOctetsCharset { get; }
 	public bool IsNoneCharset { get; }
+	public FbCharsetEnum? FbCharset { get; }
 
-	public Charset(int id, string name, int bytesPerCharacter, string systemName)
+	public Charset(int id, string name, int bytesPerCharacter, string systemName, FbCharsetEnum? fbCharset = null)
 	{
 		Identifier = id;
 		Name = name;
@@ -110,6 +116,7 @@ internal sealed class Charset
 		SystemName = systemName;
 		IsNoneCharset = false;
 		IsOctetsCharset = false;
+		FbCharset = fbCharset;
 		switch (SystemName)
 		{
 			case None:

--- a/src/FirebirdSql.Data.FirebirdClient/Common/DbField.cs
+++ b/src/FirebirdSql.Data.FirebirdClient/Common/DbField.cs
@@ -130,6 +130,7 @@ internal sealed class DbField
 	public Charset Charset
 	{
 		get { return _charset; }
+		set { _charset = value; }
 	}
 
 	public int CharCount

--- a/src/FirebirdSql.Data.FirebirdClient/FirebirdClient/FbBatchCommand.cs
+++ b/src/FirebirdSql.Data.FirebirdClient/FirebirdClient/FbBatchCommand.cs
@@ -1068,6 +1068,17 @@ public sealed class FbBatchCommand : IFbPreparedCommand, IDescriptorFiller, IDis
 				{
 					batchParameter.NullFlag = 0;
 
+					if (commandParameter.Charset > 0 && Charset.TryGetByType(commandParameter.Charset, out var charset))
+					{
+						//if command parameter charset is explicitly set, and we can find it, apply it to the statement parameter
+						batchParameter.Charset = charset;
+					}
+					else if (!Connection.InnerConnection.Database.Charset.IsNoneCharset)
+					{
+						//if the database charset is not NONE (default), apply the charset to the statement parameter
+						batchParameter.Charset = Connection.InnerConnection.Database.Charset;
+					}
+
 					switch (batchParameter.DbDataType)
 					{
 						case DbDataType.Binary:

--- a/src/FirebirdSql.Data.FirebirdClient/FirebirdClient/FbCommand.cs
+++ b/src/FirebirdSql.Data.FirebirdClient/FirebirdClient/FbCommand.cs
@@ -1260,6 +1260,17 @@ public sealed class FbCommand : DbCommand, IFbPreparedCommand, IDescriptorFiller
 				{
 					statementParameter.NullFlag = 0;
 
+					if (commandParameter.Charset > 0 && Charset.TryGetByType(commandParameter.Charset, out var charset))
+					{
+						//if command parameter charset is explicitly set, and we can find it, apply it to the statement parameter
+						statementParameter.Charset = charset;
+					}
+					else if (!Connection.InnerConnection.Database.Charset.IsNoneCharset)
+					{
+						//if the database charset is not NONE (default), apply the charset to the statement parameter
+						statementParameter.Charset = Connection.InnerConnection.Database.Charset;
+					}
+
 					switch (statementParameter.DbDataType)
 					{
 						case DbDataType.Binary:


### PR DESCRIPTION
The FbParameter class provides a 'Charset' property to specify which charset should be used when encoding/decoding a value. This property is not used anywhere. So when a parameter is set to use the 'ISO8859_1' charset, a value set by FbParameter will be written to the database using the 'NONE' (default) encoding.

When the charset is specified in the connectionstring, this is also ignored when writing a value to the database.

This PR uses the following rule to optionally apply a custom charset: 

1. The FbParameter if it is not Default or None.
2. The FbConnection/Database charset if not None.

The 'Charset' class is extended with an 'FbCharset' enum to make a match betwheen the FbParameter's Charset property and the 'Charset' class.