### PR TITLE
Use a ConcurrentDictionary to remember which calls did work

### DIFF
--- a/src/FirebirdSql.Data.FirebirdClient/Client/Native/FbClientFactory.cs
+++ b/src/FirebirdSql.Data.FirebirdClient/Client/Native/FbClientFactory.cs
@@ -83,7 +83,8 @@ internal static class FbClientFactory
 				{
 					result = BuildFbClient(dllName);
 					cache.Add(dllName, result);
-					ShutdownHelper.RegisterFbClientShutdown(() => NativeHelpers.CallIfExists(() => result.fb_shutdown(0, 0)));
+					ShutdownHelper.RegisterFbClientShutdown(
+						() => NativeHelpers.CallIfExists("shutdown", () => result.fb_shutdown(0, 0)));
 					return result;
 				}
 				finally

--- a/src/FirebirdSql.Data.FirebirdClient/Client/Native/FesStatement.cs
+++ b/src/FirebirdSql.Data.FirebirdClient/Client/Native/FesStatement.cs
@@ -371,11 +371,13 @@ internal sealed class FesStatement : StatementBase
 		descriptorFiller.Fill(_parameters, 0);
 
 		ClearStatusVector();
-		NativeHelpers.CallIfExists(() =>
-		{
-			_database.FbClient.fb_dsql_set_timeout(_statusVector, ref _handle, (uint)timeout);
-			_database.ProcessStatusVector(_statusVector);
-		});
+		NativeHelpers.CallIfExists(
+			"set_timeout",
+			() =>
+			{
+				_database.FbClient.fb_dsql_set_timeout(_statusVector, ref _handle, (uint) timeout);
+				_database.ProcessStatusVector(_statusVector);
+			});
 
 		ClearStatusVector();
 
@@ -441,11 +443,13 @@ internal sealed class FesStatement : StatementBase
 		await descriptorFiller.FillAsync(_parameters, 0, cancellationToken).ConfigureAwait(false);
 
 		ClearStatusVector();
-		NativeHelpers.CallIfExists(() =>
-		{
-			_database.FbClient.fb_dsql_set_timeout(_statusVector, ref _handle, (uint)timeout);
-			_database.ProcessStatusVector(_statusVector);
-		});
+		NativeHelpers.CallIfExists(
+			"set_timeout",
+			() =>
+			{
+				_database.FbClient.fb_dsql_set_timeout(_statusVector, ref _handle, (uint) timeout);
+				_database.ProcessStatusVector(_statusVector);
+			});
 
 		ClearStatusVector();
 

--- a/src/FirebirdSql.Data.FirebirdClient/Common/NativeHelpers.cs
+++ b/src/FirebirdSql.Data.FirebirdClient/Common/NativeHelpers.cs
@@ -16,18 +16,33 @@
 //$Authors = Jiri Cincura (jiri@cincura.net)
 
 using System;
+using System.Collections.Concurrent;
 
 namespace FirebirdSql.Data.Common;
 
 internal static class NativeHelpers
 {
-	public static void CallIfExists(Action action)
+	private static readonly ConcurrentDictionary<string, bool> _cache = new ConcurrentDictionary<string, bool>();
+
+	public static void CallIfExists(
+        string actionId,
+        Action action)
 	{
-		try
+		if (!_cache.TryGetValue(actionId, out var executionAllowed))
+		{
+			try
+			{
+				action();
+				_cache.TryAdd(actionId, true);
+			}
+			catch (EntryPointNotFoundException)
+			{
+				_cache.TryAdd(actionId, false);
+			}
+		}
+		else if (executionAllowed)
 		{
 			action();
 		}
-		catch (EntryPointNotFoundException)
-		{ }
 	}
 }


### PR DESCRIPTION
This is needed to avoid unnecessary EntryPointNotFoundException exceptions, as they massively slow down program execution - especially in development environments.

Fixes #1146 