### PR TITLE
Creation of backup and restore statistics can be switched off 

### DIFF
--- a/src/FirebirdSql.Data.FirebirdClient/Services/FbBackup.cs
+++ b/src/FirebirdSql.Data.FirebirdClient/Services/FbBackup.cs
@@ -32,8 +32,7 @@ public sealed class FbBackup : FbService
 	public int Factor { get; set; }
 	public string SkipData { get; set; }
 	public FbBackupFlags Options { get; set; }
-	public bool IncludeStatistics { get; set; } = true;
-	public FbBackupRestoreStatistics Statistics { get; set; }
+	public FbBackupRestoreStatistics? Statistics { get; set; } = default(FbBackupRestoreStatistics);
 
 	public FbBackup(string connectionString = null)
 		: base(connectionString)
@@ -68,8 +67,8 @@ public sealed class FbBackup : FbService
 				if (!string.IsNullOrEmpty(SkipData))
 					startSpb.Append2(IscCodes.isc_spb_bkp_skip_data, SkipData);
 				startSpb.Append(IscCodes.isc_spb_options, (int)Options);
-				if (IncludeStatistics)
-					startSpb.Append2(IscCodes.isc_spb_bkp_stat, Statistics.BuildConfiguration());
+				if (Statistics.HasValue)
+					startSpb.Append2(IscCodes.isc_spb_bkp_stat, Statistics.Value.BuildConfiguration());
 				if (ConnectionStringOptions.ParallelWorkers > 0)
 					startSpb.Append(IscCodes.isc_spb_bkp_parallel_workers, ConnectionStringOptions.ParallelWorkers);
 				StartTask(startSpb);
@@ -115,8 +114,8 @@ public sealed class FbBackup : FbService
 				if (!string.IsNullOrEmpty(SkipData))
 					startSpb.Append2(IscCodes.isc_spb_bkp_skip_data, SkipData);
 				startSpb.Append(IscCodes.isc_spb_options, (int)Options);
-				if (IncludeStatistics)
-					startSpb.Append2(IscCodes.isc_spb_bkp_stat, Statistics.BuildConfiguration());
+				if (Statistics.HasValue)
+					startSpb.Append2(IscCodes.isc_spb_bkp_stat, Statistics.Value.BuildConfiguration());
 				if (ConnectionStringOptions.ParallelWorkers > 0)
 					startSpb.Append(IscCodes.isc_spb_bkp_parallel_workers, ConnectionStringOptions.ParallelWorkers);
 				await StartTaskAsync(startSpb, cancellationToken).ConfigureAwait(false);

--- a/src/FirebirdSql.Data.FirebirdClient/Services/FbBackup.cs
+++ b/src/FirebirdSql.Data.FirebirdClient/Services/FbBackup.cs
@@ -32,7 +32,7 @@ public sealed class FbBackup : FbService
 	public int Factor { get; set; }
 	public string SkipData { get; set; }
 	public FbBackupFlags Options { get; set; }
-	public FbBackupRestoreStatistics? Statistics { get; set; } = default(FbBackupRestoreStatistics);
+	public FbBackupRestoreStatistics? Statistics { get; set; }
 
 	public FbBackup(string connectionString = null)
 		: base(connectionString)

--- a/src/FirebirdSql.Data.FirebirdClient/Services/FbBackup.cs
+++ b/src/FirebirdSql.Data.FirebirdClient/Services/FbBackup.cs
@@ -32,6 +32,7 @@ public sealed class FbBackup : FbService
 	public int Factor { get; set; }
 	public string SkipData { get; set; }
 	public FbBackupFlags Options { get; set; }
+	public bool IncludeStatistics { get; set; } = true;
 	public FbBackupRestoreStatistics Statistics { get; set; }
 
 	public FbBackup(string connectionString = null)
@@ -67,7 +68,8 @@ public sealed class FbBackup : FbService
 				if (!string.IsNullOrEmpty(SkipData))
 					startSpb.Append2(IscCodes.isc_spb_bkp_skip_data, SkipData);
 				startSpb.Append(IscCodes.isc_spb_options, (int)Options);
-				startSpb.Append2(IscCodes.isc_spb_bkp_stat, Statistics.BuildConfiguration());
+				if (IncludeStatistics)
+					startSpb.Append2(IscCodes.isc_spb_bkp_stat, Statistics.BuildConfiguration());
 				if (ConnectionStringOptions.ParallelWorkers > 0)
 					startSpb.Append(IscCodes.isc_spb_bkp_parallel_workers, ConnectionStringOptions.ParallelWorkers);
 				StartTask(startSpb);
@@ -113,7 +115,8 @@ public sealed class FbBackup : FbService
 				if (!string.IsNullOrEmpty(SkipData))
 					startSpb.Append2(IscCodes.isc_spb_bkp_skip_data, SkipData);
 				startSpb.Append(IscCodes.isc_spb_options, (int)Options);
-				startSpb.Append2(IscCodes.isc_spb_bkp_stat, Statistics.BuildConfiguration());
+				if (IncludeStatistics)
+					startSpb.Append2(IscCodes.isc_spb_bkp_stat, Statistics.BuildConfiguration());
 				if (ConnectionStringOptions.ParallelWorkers > 0)
 					startSpb.Append(IscCodes.isc_spb_bkp_parallel_workers, ConnectionStringOptions.ParallelWorkers);
 				await StartTaskAsync(startSpb, cancellationToken).ConfigureAwait(false);

--- a/src/FirebirdSql.Data.FirebirdClient/Services/FbRestore.cs
+++ b/src/FirebirdSql.Data.FirebirdClient/Services/FbRestore.cs
@@ -46,8 +46,7 @@ public sealed class FbRestore : FbService
 	public bool ReadOnly { get; set; }
 	public string SkipData { get; set; }
 	public FbRestoreFlags Options { get; set; }
-	public bool IncludeStatistics { get; set; } = true;
-	public FbBackupRestoreStatistics Statistics { get; set; }
+	public FbBackupRestoreStatistics? Statistics { get; set; }
 
 	public FbRestore(string connectionString = null)
 		: base(connectionString)
@@ -83,8 +82,8 @@ public sealed class FbRestore : FbService
 				if (!string.IsNullOrEmpty(SkipData))
 					startSpb.Append2(IscCodes.isc_spb_res_skip_data, SkipData);
 				startSpb.Append(IscCodes.isc_spb_options, (int)Options);
-				if (IncludeStatistics)
-					startSpb.Append2(IscCodes.isc_spb_res_stat, Statistics.BuildConfiguration());
+				if (Statistics.HasValue)
+					startSpb.Append2(IscCodes.isc_spb_res_stat, Statistics.Value.BuildConfiguration());
 				if (ConnectionStringOptions.ParallelWorkers > 0)
 					startSpb.Append(IscCodes.isc_spb_res_parallel_workers, ConnectionStringOptions.ParallelWorkers);
 				StartTask(startSpb);
@@ -131,8 +130,8 @@ public sealed class FbRestore : FbService
 				if (!string.IsNullOrEmpty(SkipData))
 					startSpb.Append2(IscCodes.isc_spb_res_skip_data, SkipData);
 				startSpb.Append(IscCodes.isc_spb_options, (int)Options);
-				if (IncludeStatistics)
-					startSpb.Append2(IscCodes.isc_spb_res_stat, Statistics.BuildConfiguration());
+				if (Statistics.HasValue)
+					startSpb.Append2(IscCodes.isc_spb_res_stat, Statistics.Value.BuildConfiguration());
 				if (ConnectionStringOptions.ParallelWorkers > 0)
 					startSpb.Append(IscCodes.isc_spb_res_parallel_workers, ConnectionStringOptions.ParallelWorkers);
 				await StartTaskAsync(startSpb, cancellationToken).ConfigureAwait(false);

--- a/src/FirebirdSql.Data.FirebirdClient/Services/FbRestore.cs
+++ b/src/FirebirdSql.Data.FirebirdClient/Services/FbRestore.cs
@@ -46,6 +46,7 @@ public sealed class FbRestore : FbService
 	public bool ReadOnly { get; set; }
 	public string SkipData { get; set; }
 	public FbRestoreFlags Options { get; set; }
+	public bool IncludeStatistics { get; set; } = true;
 	public FbBackupRestoreStatistics Statistics { get; set; }
 
 	public FbRestore(string connectionString = null)
@@ -82,7 +83,8 @@ public sealed class FbRestore : FbService
 				if (!string.IsNullOrEmpty(SkipData))
 					startSpb.Append2(IscCodes.isc_spb_res_skip_data, SkipData);
 				startSpb.Append(IscCodes.isc_spb_options, (int)Options);
-				startSpb.Append2(IscCodes.isc_spb_res_stat, Statistics.BuildConfiguration());
+				if (IncludeStatistics)
+					startSpb.Append2(IscCodes.isc_spb_res_stat, Statistics.BuildConfiguration());
 				if (ConnectionStringOptions.ParallelWorkers > 0)
 					startSpb.Append(IscCodes.isc_spb_res_parallel_workers, ConnectionStringOptions.ParallelWorkers);
 				StartTask(startSpb);
@@ -129,7 +131,8 @@ public sealed class FbRestore : FbService
 				if (!string.IsNullOrEmpty(SkipData))
 					startSpb.Append2(IscCodes.isc_spb_res_skip_data, SkipData);
 				startSpb.Append(IscCodes.isc_spb_options, (int)Options);
-				startSpb.Append2(IscCodes.isc_spb_res_stat, Statistics.BuildConfiguration());
+				if (IncludeStatistics)
+					startSpb.Append2(IscCodes.isc_spb_res_stat, Statistics.BuildConfiguration());
 				if (ConnectionStringOptions.ParallelWorkers > 0)
 					startSpb.Append(IscCodes.isc_spb_res_parallel_workers, ConnectionStringOptions.ParallelWorkers);
 				await StartTaskAsync(startSpb, cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
By setting the new property `FbBackup.IncludeStatistics` to `false `fixes #1180.
To ensure backward compatibility, the default value of the `FbBackup.IncludeStatistics` property is `true`.