### PR TITLE
Fix scaffolding error with Firebird 2.5 caused by boolean conversion

### DIFF
--- a/src/FirebirdSql.EntityFrameworkCore.Firebird/Scaffolding/Internal/FbDatabaseModelFactory.cs
+++ b/src/FirebirdSql.EntityFrameworkCore.Firebird/Scaffolding/Internal/FbDatabaseModelFactory.cs
@@ -311,7 +311,7 @@ public class FbDatabaseModelFactory : DatabaseModelFactory
 		@"SELECT
                trim(I.rdb$index_name) as INDEX_NAME,
                COALESCE(I.rdb$unique_flag, 0) as IS_UNIQUE,
-               Coalesce(I.rdb$index_type, 0) = 1 as IS_DESC,
+               Coalesce(I.rdb$index_type, 0) as IS_DESC,
                list(trim(sg.RDB$FIELD_NAME)) as COLUMNS
               FROM
                RDB$INDICES i


### PR DESCRIPTION
`Coalesce(I.rdb$index_type, 0) = 1 as IS_DESC,` gives following error on Firebird 2.5
According to documentation `rdb$index_type` can be 0 or 1 so we can drop boolean conversion

```
FirebirdSql.Data.FirebirdClient.FbException (0x80004005): Dynamic SQL Error
SQL error code = -104
Token unknown - line 4, column 46
=
 ---> FirebirdSql.Data.Common.IscException: Dynamic SQL Error
SQL error code = -104
Token unknown - line 4, column 46
=
   at FirebirdSql.Data.Client.Managed.IResponseExtensions.HandleResponseException(IResponse response)
   at FirebirdSql.Data.Client.Managed.Version10.GdsDatabase.ReadResponse()
   at FirebirdSql.Data.Client.Managed.Version11.GdsStatement.Prepare(String commandText)
   at FirebirdSql.Data.FirebirdClient.FbCommand.Prepare(Boolean returnsSet)
   at FirebirdSql.Data.FirebirdClient.FbCommand.ExecuteCommand(CommandBehavior behavior, Boolean returnsSet)
   at FirebirdSql.Data.FirebirdClient.FbCommand.ExecuteReader(CommandBehavior behavior)
   at FirebirdSql.Data.FirebirdClient.FbCommand.ExecuteReader(CommandBehavior behavior)
   at FirebirdSql.Data.FirebirdClient.FbCommand.ExecuteDbDataReader(CommandBehavior behavior)
   at FirebirdSql.EntityFrameworkCore.Firebird.Scaffolding.Internal.FbDatabaseModelFactory.GetIndexes(DbConnection connection, IReadOnlyList`1 tables, Func`2 tableFilter)
   at FirebirdSql.EntityFrameworkCore.Firebird.Scaffolding.Internal.FbDatabaseModelFactory.GetTables(DbConnection connection, Func`2 filter)
   at FirebirdSql.EntityFrameworkCore.Firebird.Scaffolding.Internal.FbDatabaseModelFactory.Create(DbConnection connection, DatabaseModelFactoryOptions options)
   at FirebirdSql.EntityFrameworkCore.Firebird.Scaffolding.Internal.FbDatabaseModelFactory.Create(String connectionString, DatabaseModelFactoryOptions options)
   at Microsoft.EntityFrameworkCore.Scaffolding.Internal.ReverseEngineerScaffolder.ScaffoldModel(String connectionString, DatabaseModelFactoryOptions databaseOptions, ModelReverseEngineerOptions modelOptions, ModelCodeGenerationOptions codeOptions)
   at Microsoft.EntityFrameworkCore.Design.Internal.DatabaseOperations.ScaffoldContext(String provider, String connectionString, String outputDir, String outputContextDir, String dbContextClassName, IEnumerable`1 schemas, IEnumerable`1 tables, String modelNamespace, String contextNamespace, Boolean useDataAnnotations, Boolean overwriteFiles, Boolean useDatabaseNames, Boolean suppressOnConfiguring, Boolean noPluralize)
   at Microsoft.EntityFrameworkCore.Design.OperationExecutor.ScaffoldContextImpl(String provider, String connectionString, String outputDir, String outputDbContextDir, String dbContextClassName, IEnumerable`1 schemaFilters, IEnumerable`1 tableFilters, String modelNamespace, String contextNamespace, Boolean useDataAnnotations, Boolean overwriteFiles, Boolean useDatabaseNames, Boolean suppressOnConfiguring, Boolean noPluralize)
   at Microsoft.EntityFrameworkCore.Design.OperationExecutor.ScaffoldContext.<>c__DisplayClass0_0.<.ctor>b__0()
   at Microsoft.EntityFrameworkCore.Design.OperationExecutor.OperationBase.<>c__DisplayClass3_0`1.<Execute>b__0()
   at Microsoft.EntityFrameworkCore.Design.OperationExecutor.OperationBase.Execute(Action action)
```