### PR TITLE
Add isUnicode parameter to StringLiteralQueryType function

### DIFF
--- a/src/FirebirdSql.EntityFrameworkCore.Firebird/Query/Internal/FbQuerySqlGenerator.cs
+++ b/src/FirebirdSql.EntityFrameworkCore.Firebird/Query/Internal/FbQuerySqlGenerator.cs
@@ -191,8 +191,9 @@ public class FbQuerySqlGenerator : QuerySqlGenerator
 		base.VisitSqlConstant(sqlConstantExpression);
 		if (shouldExplicitStringLiteralTypes)
 		{
+			var isUnicode = FbTypeMappingSource.IsUnicode(sqlConstantExpression.TypeMapping);	
 			Sql.Append(" AS ");
-			Sql.Append(((IFbSqlGenerationHelper)Dependencies.SqlGenerationHelper).StringLiteralQueryType(sqlConstantExpression.Value as string));
+			Sql.Append(((IFbSqlGenerationHelper)Dependencies.SqlGenerationHelper).StringLiteralQueryType(sqlConstantExpression.Value as string, isUnicode));
 			Sql.Append(")");
 		}
 		return sqlConstantExpression;

--- a/src/FirebirdSql.EntityFrameworkCore.Firebird/Storage/Internal/FbSqlGenerationHelper.cs
+++ b/src/FirebirdSql.EntityFrameworkCore.Firebird/Storage/Internal/FbSqlGenerationHelper.cs
@@ -27,11 +27,15 @@ public class FbSqlGenerationHelper : RelationalSqlGenerationHelper, IFbSqlGenera
 		: base(dependencies)
 	{ }
 
-	public virtual string StringLiteralQueryType(string s)
+	public virtual string StringLiteralQueryType(string s, bool isUnicode = true)
 	{
 		var length = MinimumStringQueryTypeLength(s);
 		EnsureStringLiteralQueryTypeLength(length);
-		return $"VARCHAR({length}) CHARACTER SET UTF8";
+		if(isUnicode)
+		{
+			return $"VARCHAR({length}) CHARACTER SET UTF8";
+		}
+		return $"VARCHAR({length})";
 	}
 
 	public virtual string StringParameterQueryType(bool isUnicode)

--- a/src/FirebirdSql.EntityFrameworkCore.Firebird/Storage/Internal/FbSqlGenerationHelper.cs
+++ b/src/FirebirdSql.EntityFrameworkCore.Firebird/Storage/Internal/FbSqlGenerationHelper.cs
@@ -30,12 +30,8 @@ public class FbSqlGenerationHelper : RelationalSqlGenerationHelper, IFbSqlGenera
 	public virtual string StringLiteralQueryType(string s, bool isUnicode = true)
 	{
 		var length = MinimumStringQueryTypeLength(s);
-		EnsureStringLiteralQueryTypeLength(length);
-		if(isUnicode)
-		{
-			return $"VARCHAR({length}) CHARACTER SET UTF8";
-		}
-		return $"VARCHAR({length})";
+		var charset = isUnicode ? " CHARACTER SET UTF8" : "";
+		return $"VARCHAR({length}){charset}";
 	}
 
 	public virtual string StringParameterQueryType(bool isUnicode)

--- a/src/FirebirdSql.EntityFrameworkCore.Firebird/Storage/Internal/FbSqlGenerationHelper.cs
+++ b/src/FirebirdSql.EntityFrameworkCore.Firebird/Storage/Internal/FbSqlGenerationHelper.cs
@@ -30,7 +30,7 @@ public class FbSqlGenerationHelper : RelationalSqlGenerationHelper, IFbSqlGenera
 	public virtual string StringLiteralQueryType(string s, bool isUnicode = true)
 	{
 		var length = MinimumStringQueryTypeLength(s);
-		var charset = isUnicode ? " CHARACTER SET UTF8" : "";
+		var charset = isUnicode ? " CHARACTER SET UTF8" : string.Empty;
 		return $"VARCHAR({length}){charset}";
 	}
 

--- a/src/FirebirdSql.EntityFrameworkCore.Firebird/Storage/Internal/IFbSqlGenerationHelper.cs
+++ b/src/FirebirdSql.EntityFrameworkCore.Firebird/Storage/Internal/IFbSqlGenerationHelper.cs
@@ -22,7 +22,7 @@ namespace FirebirdSql.EntityFrameworkCore.Firebird.Storage.Internal;
 
 public interface IFbSqlGenerationHelper : ISqlGenerationHelper
 {
-	string StringLiteralQueryType(string s);
+	string StringLiteralQueryType(string s, bool isUnicode);
 	string StringParameterQueryType(bool isUnicode);
 	void GenerateBlockParameterName(StringBuilder builder, string name);
 	string AlternativeStatementTerminator { get; }


### PR DESCRIPTION
included the isUnicode parameter in the StringLiteralQueryType method so that it can be turned off if desired. tests performed on Firebird 4 and Firebird 5