### PR TITLE
Fix FbZonedDateTime invalid cast

### DIFF
--- a/src/FirebirdSql.Data.FirebirdClient.Tests/FbZonedDateTimeTypeTests.cs
+++ b/src/FirebirdSql.Data.FirebirdClient.Tests/FbZonedDateTimeTypeTests.cs
@@ -50,7 +50,7 @@ public class FbZonedDateTimeTypeTests
 	[Test]
 	public void ConvertToDateTimeShouldNotThrow()
 	{
-		FbZonedDateTime fbZonedDateTime = new(new DateTime(2020, 12, 4, 10, 38, 0, DateTimeKind.Utc), "UTC");
+		var fbZonedDateTime = new FbZonedDateTime(new DateTime(2020, 12, 4, 10, 38, 0, DateTimeKind.Utc), "UTC");
 		
 		Assert.DoesNotThrow(() => Convert.ChangeType(fbZonedDateTime, typeof(DateTime)));
 	}

--- a/src/FirebirdSql.Data.FirebirdClient.Tests/FbZonedDateTimeTypeTests.cs
+++ b/src/FirebirdSql.Data.FirebirdClient.Tests/FbZonedDateTimeTypeTests.cs
@@ -47,6 +47,14 @@ public class FbZonedDateTimeTypeTests
 		Assert.AreNotEqual(expected, actual);
 	}
 
+	[Test]
+	public void ConvertToDateTimeShouldNotThrow()
+	{
+		FbZonedDateTime fbZonedDateTime = new(new DateTime(2020, 12, 4, 10, 38, 0, DateTimeKind.Utc), "UTC");
+		
+		Assert.DoesNotThrow(() => Convert.ChangeType(fbZonedDateTime, typeof(DateTime)));
+	}
+
 	public void DateTimeShouldBeUtc()
 	{
 		Assert.Throws<ArgumentException>(() =>

--- a/src/FirebirdSql.Data.FirebirdClient/Types/FbZonedDateTime.cs
+++ b/src/FirebirdSql.Data.FirebirdClient/Types/FbZonedDateTime.cs
@@ -78,25 +78,25 @@ public readonly struct FbZonedDateTime : IConvertible, IEquatable<FbZonedDateTim
 
 	bool IConvertible.ToBoolean(IFormatProvider provider) => throw new InvalidCastException(nameof(Boolean));
 
-	byte IConvertible. ToByte(IFormatProvider provider) => throw new InvalidCastException(nameof(Byte));
+	byte IConvertible.ToByte(IFormatProvider provider) => throw new InvalidCastException(nameof(Byte));
 
-	char IConvertible. ToChar(IFormatProvider provider) => throw new InvalidCastException(nameof(Char));
+	char IConvertible.ToChar(IFormatProvider provider) => throw new InvalidCastException(nameof(Char));
 
-	DateTime IConvertible. ToDateTime(IFormatProvider provider) => DateTime;
+	DateTime IConvertible.ToDateTime(IFormatProvider provider) => DateTime;
 
-	decimal IConvertible. ToDecimal(IFormatProvider provider) => throw new InvalidCastException(nameof(Decimal));
+	decimal IConvertible.ToDecimal(IFormatProvider provider) => throw new InvalidCastException(nameof(Decimal));
 
-	double IConvertible. ToDouble(IFormatProvider provider) => throw new InvalidCastException(nameof(Double));
+	double IConvertible.ToDouble(IFormatProvider provider) => throw new InvalidCastException(nameof(Double));
 
-	short IConvertible. ToInt16(IFormatProvider provider) => throw new InvalidCastException(nameof(Int16));
+	short IConvertible.ToInt16(IFormatProvider provider) => throw new InvalidCastException(nameof(Int16));
 
-	int IConvertible. ToInt32(IFormatProvider provider) => throw new InvalidCastException(nameof(Int32));
+	int IConvertible.ToInt32(IFormatProvider provider) => throw new InvalidCastException(nameof(Int32));
 
-	long IConvertible. ToInt64(IFormatProvider provider) => throw new InvalidCastException(nameof(Int64));
+	long IConvertible.ToInt64(IFormatProvider provider) => throw new InvalidCastException(nameof(Int64));
 
-	sbyte IConvertible. ToSByte(IFormatProvider provider) => throw new InvalidCastException(nameof(SByte));
+	sbyte IConvertible.ToSByte(IFormatProvider provider) => throw new InvalidCastException(nameof(SByte));
 
-	float IConvertible. ToSingle(IFormatProvider provider) => throw new InvalidCastException(nameof(Single));
+	float IConvertible.ToSingle(IFormatProvider provider) => throw new InvalidCastException(nameof(Single));
 
 	string IConvertible.ToString(IFormatProvider provider) => ToString();
 

--- a/src/FirebirdSql.Data.FirebirdClient/Types/FbZonedDateTime.cs
+++ b/src/FirebirdSql.Data.FirebirdClient/Types/FbZonedDateTime.cs
@@ -21,7 +21,7 @@ using System.Runtime.InteropServices;
 namespace FirebirdSql.Data.Types;
 
 [StructLayout(LayoutKind.Auto)]
-public readonly struct FbZonedDateTime : IConvertible, IEquatable<FbZonedDateTime>
+public readonly struct FbZonedDateTime : IEquatable<FbZonedDateTime>, IConvertible
 {
 	public DateTime DateTime { get; }
 	public string TimeZone { get; }
@@ -76,13 +76,18 @@ public readonly struct FbZonedDateTime : IConvertible, IEquatable<FbZonedDateTim
 
 	TypeCode IConvertible.GetTypeCode() => TypeCode.Object;
 
+	DateTime IConvertible.ToDateTime(IFormatProvider provider) => DateTime;
+
+	string IConvertible.ToString(IFormatProvider provider) => ToString();
+
+	object IConvertible.ToType(Type conversionType, IFormatProvider provider)
+		=> ReferenceEquals(conversionType, typeof(FbZonedDateTime)) ? this : throw new InvalidCastException(conversionType?.FullName);
+
 	bool IConvertible.ToBoolean(IFormatProvider provider) => throw new InvalidCastException(nameof(Boolean));
 
 	byte IConvertible.ToByte(IFormatProvider provider) => throw new InvalidCastException(nameof(Byte));
 
 	char IConvertible.ToChar(IFormatProvider provider) => throw new InvalidCastException(nameof(Char));
-
-	DateTime IConvertible.ToDateTime(IFormatProvider provider) => DateTime;
 
 	decimal IConvertible.ToDecimal(IFormatProvider provider) => throw new InvalidCastException(nameof(Decimal));
 
@@ -97,18 +102,6 @@ public readonly struct FbZonedDateTime : IConvertible, IEquatable<FbZonedDateTim
 	sbyte IConvertible.ToSByte(IFormatProvider provider) => throw new InvalidCastException(nameof(SByte));
 
 	float IConvertible.ToSingle(IFormatProvider provider) => throw new InvalidCastException(nameof(Single));
-
-	string IConvertible.ToString(IFormatProvider provider) => ToString();
-
-	object IConvertible.ToType(Type conversionType, IFormatProvider provider)
-	{
-		if (ReferenceEquals(conversionType, typeof(FbZonedDateTime)))
-		{
-			return this;
-		}
-
-		throw new InvalidCastException(conversionType?.FullName);
-	}
 
 	ushort IConvertible.ToUInt16(IFormatProvider provider) => throw new InvalidCastException(nameof(UInt16));
 

--- a/src/FirebirdSql.Data.FirebirdClient/Types/FbZonedDateTime.cs
+++ b/src/FirebirdSql.Data.FirebirdClient/Types/FbZonedDateTime.cs
@@ -100,7 +100,15 @@ public readonly struct FbZonedDateTime : IConvertible, IEquatable<FbZonedDateTim
 
 	public string ToString(IFormatProvider provider) => throw new InvalidCastException(nameof(String));
 
-	public object ToType(Type conversionType, IFormatProvider provider) => throw new InvalidCastException(nameof(conversionType));
+	public object ToType(Type conversionType, IFormatProvider provider)
+	{
+		if (ReferenceEquals(conversionType, typeof(FbZonedDateTime)))
+		{
+			return this;
+		}
+
+		throw new InvalidCastException(conversionType?.FullName);
+	}
 
 	public ushort ToUInt16(IFormatProvider provider) => throw new InvalidCastException(nameof(UInt16));
 

--- a/src/FirebirdSql.Data.FirebirdClient/Types/FbZonedDateTime.cs
+++ b/src/FirebirdSql.Data.FirebirdClient/Types/FbZonedDateTime.cs
@@ -21,7 +21,7 @@ using System.Runtime.InteropServices;
 namespace FirebirdSql.Data.Types;
 
 [StructLayout(LayoutKind.Auto)]
-public readonly struct FbZonedDateTime : IEquatable<FbZonedDateTime>
+public readonly struct FbZonedDateTime : IConvertible, IEquatable<FbZonedDateTime>
 {
 	public DateTime DateTime { get; }
 	public string TimeZone { get; }
@@ -73,6 +73,40 @@ public readonly struct FbZonedDateTime : IEquatable<FbZonedDateTime>
 	}
 
 	public bool Equals(FbZonedDateTime other) => DateTime.Equals(other.DateTime) && TimeZone.Equals(other.TimeZone, StringComparison.OrdinalIgnoreCase);
+
+	public TypeCode GetTypeCode() => TypeCode.Object;
+
+	public bool ToBoolean(IFormatProvider provider) => throw new InvalidCastException(nameof(Boolean));
+
+	public byte ToByte(IFormatProvider provider) => throw new InvalidCastException(nameof(Byte));
+
+	public char ToChar(IFormatProvider provider) => throw new InvalidCastException(nameof(Char));
+
+	public DateTime ToDateTime(IFormatProvider provider) => DateTime;
+
+	public decimal ToDecimal(IFormatProvider provider) => throw new InvalidCastException(nameof(Decimal));
+
+	public double ToDouble(IFormatProvider provider) => throw new InvalidCastException(nameof(Double));
+
+	public short ToInt16(IFormatProvider provider) => throw new InvalidCastException(nameof(Int16));
+
+	public int ToInt32(IFormatProvider provider) => throw new InvalidCastException(nameof(Int32));
+
+	public long ToInt64(IFormatProvider provider) => throw new InvalidCastException(nameof(Int64));
+
+	public sbyte ToSByte(IFormatProvider provider) => throw new InvalidCastException(nameof(SByte));
+
+	public float ToSingle(IFormatProvider provider) => throw new InvalidCastException(nameof(Single));
+
+	public string ToString(IFormatProvider provider) => throw new InvalidCastException(nameof(String));
+
+	public object ToType(Type conversionType, IFormatProvider provider) => throw new InvalidCastException(nameof(conversionType));
+
+	public ushort ToUInt16(IFormatProvider provider) => throw new InvalidCastException(nameof(UInt16));
+
+	public uint ToUInt32(IFormatProvider provider) => throw new InvalidCastException(nameof(UInt32));
+
+	public ulong ToUInt64(IFormatProvider provider) => throw new InvalidCastException(nameof(UInt64));
 
 	public static bool operator ==(FbZonedDateTime lhs, FbZonedDateTime rhs) => lhs.Equals(rhs);
 

--- a/src/FirebirdSql.Data.FirebirdClient/Types/FbZonedDateTime.cs
+++ b/src/FirebirdSql.Data.FirebirdClient/Types/FbZonedDateTime.cs
@@ -74,33 +74,33 @@ public readonly struct FbZonedDateTime : IConvertible, IEquatable<FbZonedDateTim
 
 	public bool Equals(FbZonedDateTime other) => DateTime.Equals(other.DateTime) && TimeZone.Equals(other.TimeZone, StringComparison.OrdinalIgnoreCase);
 
-	public TypeCode GetTypeCode() => TypeCode.Object;
+	TypeCode IConvertible.GetTypeCode() => TypeCode.Object;
 
-	public bool ToBoolean(IFormatProvider provider) => throw new InvalidCastException(nameof(Boolean));
+	bool IConvertible.ToBoolean(IFormatProvider provider) => throw new InvalidCastException(nameof(Boolean));
 
-	public byte ToByte(IFormatProvider provider) => throw new InvalidCastException(nameof(Byte));
+	byte IConvertible. ToByte(IFormatProvider provider) => throw new InvalidCastException(nameof(Byte));
 
-	public char ToChar(IFormatProvider provider) => throw new InvalidCastException(nameof(Char));
+	char IConvertible. ToChar(IFormatProvider provider) => throw new InvalidCastException(nameof(Char));
 
-	public DateTime ToDateTime(IFormatProvider provider) => DateTime;
+	DateTime IConvertible. ToDateTime(IFormatProvider provider) => DateTime;
 
-	public decimal ToDecimal(IFormatProvider provider) => throw new InvalidCastException(nameof(Decimal));
+	decimal IConvertible. ToDecimal(IFormatProvider provider) => throw new InvalidCastException(nameof(Decimal));
 
-	public double ToDouble(IFormatProvider provider) => throw new InvalidCastException(nameof(Double));
+	double IConvertible. ToDouble(IFormatProvider provider) => throw new InvalidCastException(nameof(Double));
 
-	public short ToInt16(IFormatProvider provider) => throw new InvalidCastException(nameof(Int16));
+	short IConvertible. ToInt16(IFormatProvider provider) => throw new InvalidCastException(nameof(Int16));
 
-	public int ToInt32(IFormatProvider provider) => throw new InvalidCastException(nameof(Int32));
+	int IConvertible. ToInt32(IFormatProvider provider) => throw new InvalidCastException(nameof(Int32));
 
-	public long ToInt64(IFormatProvider provider) => throw new InvalidCastException(nameof(Int64));
+	long IConvertible. ToInt64(IFormatProvider provider) => throw new InvalidCastException(nameof(Int64));
 
-	public sbyte ToSByte(IFormatProvider provider) => throw new InvalidCastException(nameof(SByte));
+	sbyte IConvertible. ToSByte(IFormatProvider provider) => throw new InvalidCastException(nameof(SByte));
 
-	public float ToSingle(IFormatProvider provider) => throw new InvalidCastException(nameof(Single));
+	float IConvertible. ToSingle(IFormatProvider provider) => throw new InvalidCastException(nameof(Single));
 
-	public string ToString(IFormatProvider provider) => throw new InvalidCastException(nameof(String));
+	string IConvertible.ToString(IFormatProvider provider) => ToString();
 
-	public object ToType(Type conversionType, IFormatProvider provider)
+	object IConvertible.ToType(Type conversionType, IFormatProvider provider)
 	{
 		if (ReferenceEquals(conversionType, typeof(FbZonedDateTime)))
 		{
@@ -110,11 +110,11 @@ public readonly struct FbZonedDateTime : IConvertible, IEquatable<FbZonedDateTim
 		throw new InvalidCastException(conversionType?.FullName);
 	}
 
-	public ushort ToUInt16(IFormatProvider provider) => throw new InvalidCastException(nameof(UInt16));
+	ushort IConvertible.ToUInt16(IFormatProvider provider) => throw new InvalidCastException(nameof(UInt16));
 
-	public uint ToUInt32(IFormatProvider provider) => throw new InvalidCastException(nameof(UInt32));
+	uint IConvertible.ToUInt32(IFormatProvider provider) => throw new InvalidCastException(nameof(UInt32));
 
-	public ulong ToUInt64(IFormatProvider provider) => throw new InvalidCastException(nameof(UInt64));
+	ulong IConvertible.ToUInt64(IFormatProvider provider) => throw new InvalidCastException(nameof(UInt64));
 
 	public static bool operator ==(FbZonedDateTime lhs, FbZonedDateTime rhs) => lhs.Equals(rhs);
 


### PR DESCRIPTION
Fixes #1177 

Implement IConvertible for FbZonedDateTime.

Adds an implementation for the `IConvertible` interface method `ToDateTime`. It returns the `DateTime` property of the `FbZonedDateTime` struct. This allows an instance of `FbZonedDateTime` to be converted to a `DateTime` object using the `IConvertible` interface.