### PR TITLE
Fix GTT tables being mapped to views

### DIFF
--- a/src/FirebirdSql.EntityFrameworkCore.Firebird/Scaffolding/Internal/FbDatabaseModelFactory.cs
+++ b/src/FirebirdSql.EntityFrameworkCore.Firebird/Scaffolding/Internal/FbDatabaseModelFactory.cs
@@ -121,9 +121,9 @@ public class FbDatabaseModelFactory : DatabaseModelFactory
 					var comment = reader.GetString(1);
 					var type = reader.GetInt32(2);
 
-					var table = type == 0
-						? new DatabaseTable()
-						: new DatabaseView();
+					var table = type == 1
+						? new DatabaseView()
+						: new DatabaseTable();
 
 					table.Schema = null;
 					table.Name = name;


### PR DESCRIPTION
While scaffolding it did a simple check for table type 0, which is only normal tables, things like External tables and GTT tables get mapped to views.