### PR TITLE
(Improvements) Ring-buffer and XdrReaderWriter optimizations, assorted Span/Memory method additions

### DIFF
--- a/src/FirebirdSql.Data.FirebirdClient/Client/Managed/DataProviderStreamWrapper.cs
+++ b/src/FirebirdSql.Data.FirebirdClient/Client/Managed/DataProviderStreamWrapper.cs
@@ -15,8 +15,10 @@
 
 //$Authors = Jiri Cincura (jiri@cincura.net)
 
+using System;
 using System.IO;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -36,10 +38,29 @@ sealed class DataProviderStreamWrapper : IDataProvider
 	{
 		return _stream.Read(buffer, offset, count);
 	}
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public int Read(Span<byte> buffer, int offset, int count)
+	{
+		return _stream.Read(buffer[offset..(offset+count)]);
+	}
+
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	public ValueTask<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken = default)
 	{
 		return new ValueTask<int>(_stream.ReadAsync(buffer, offset, count, cancellationToken));
+	}
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public ValueTask<int> ReadAsync(Memory<byte> buffer, int offset, int count, CancellationToken cancellationToken = default)
+    {
+        return _stream.ReadAsync(buffer.Slice(offset, count), cancellationToken);
+    }
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public void Write(ReadOnlySpan<byte> buffer)
+	{
+		_stream.Write(buffer);
 	}
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -52,6 +73,12 @@ sealed class DataProviderStreamWrapper : IDataProvider
 	{
 		return new ValueTask(_stream.WriteAsync(buffer, offset, count, cancellationToken));
 	}
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, int offset, int count, CancellationToken cancellationToken = default)
+    {
+        return _stream.WriteAsync(buffer.Slice(offset, count), cancellationToken);
+    }
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	public void Flush()

--- a/src/FirebirdSql.Data.FirebirdClient/Client/Managed/FirebirdNetworkHandlingWrapper.cs
+++ b/src/FirebirdSql.Data.FirebirdClient/Client/Managed/FirebirdNetworkHandlingWrapper.cs
@@ -16,8 +16,9 @@
 //$Authors = Jiri Cincura (jiri@cincura.net)
 
 using System;
-using System.Collections.Generic;
+using System.Buffers;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using FirebirdSql.Data.Common;
@@ -30,11 +31,12 @@ sealed class FirebirdNetworkHandlingWrapper : IDataProvider, ITracksIOFailure
 	public const string EncryptionName = "Arc4";
 
 	const int PreferredBufferSize = 32 * 1024;
+	const int DirectReadWriteThreshold = 8 * 1024;
 
 	readonly IDataProvider _dataProvider;
 
-	readonly Queue<byte> _outputBuffer;
-	readonly Queue<byte> _inputBuffer;
+	readonly ByteRingBuffer _outputBuffer;
+	readonly ByteRingBuffer _inputBuffer;
 	readonly byte[] _readBuffer;
 
 	byte[] _compressionBuffer;
@@ -48,8 +50,8 @@ sealed class FirebirdNetworkHandlingWrapper : IDataProvider, ITracksIOFailure
 	{
 		_dataProvider = dataProvider;
 
-		_outputBuffer = new Queue<byte>(PreferredBufferSize);
-		_inputBuffer = new Queue<byte>(PreferredBufferSize);
+		_outputBuffer = new ByteRingBuffer(PreferredBufferSize);
+		_inputBuffer = new ByteRingBuffer(PreferredBufferSize);
 		_readBuffer = new byte[PreferredBufferSize];
 	}
 
@@ -57,151 +59,242 @@ sealed class FirebirdNetworkHandlingWrapper : IDataProvider, ITracksIOFailure
 
 	public int Read(byte[] buffer, int offset, int count)
 	{
-		if (_inputBuffer.Count < count)
+		if (count <= 0)
+			return 0;
+
+		if (_inputBuffer.Count == 0 && _decompressor == null && count >= DirectReadWriteThreshold)
 		{
-			var readBuffer = _readBuffer;
 			int read;
 			try
 			{
-				read = _dataProvider.Read(readBuffer, 0, readBuffer.Length);
+				read = _dataProvider.Read(buffer, offset, count);
 			}
 			catch (IOException)
 			{
 				IOFailed = true;
 				throw;
 			}
-			if (read != 0)
+
+			if (read > 0 && _decryptor != null)
 			{
-				if (_decryptor != null)
-				{
-					_decryptor.ProcessBytes(readBuffer, 0, read, readBuffer, 0);
-				}
-				if (_decompressor != null)
-				{
-					read = HandleDecompression(readBuffer, read);
-					readBuffer = _compressionBuffer;
-				}
-				WriteToInputBuffer(readBuffer, read);
+				_decryptor.ProcessBytes(buffer, offset, read, buffer, offset);
 			}
+			return read;
 		}
-		var dataLength = ReadFromInputBuffer(buffer, offset, count);
-		return dataLength;
+
+		if (_inputBuffer.Count < count)
+		{
+			FillInputBuffer();
+		}
+
+		return _inputBuffer.CopyTo(buffer.AsSpan(offset, count));
 	}
 
 	public int Read(Span<byte> buffer, int offset, int count)
 	{
-		if (_inputBuffer.Count < count) {
-			var readBuffer = _readBuffer;
-			int read;
-			try {
-				read = _dataProvider.Read(readBuffer, 0, readBuffer.Length);
+		if (count <= 0)
+			return 0;
+
+		// Cannot decrypt into arbitrary spans (BouncyCastle API is byte[] based),
+		// so bypass only when no transforms are active.
+		if (_inputBuffer.Count == 0 && _decompressor == null && _decryptor == null && count >= DirectReadWriteThreshold)
+		{
+			try
+			{
+				return _dataProvider.Read(buffer, offset, count);
 			}
 			catch (IOException) {
 				IOFailed = true;
 				throw;
 			}
-			if (read != 0) {
-				if (_decryptor != null) {
-					_decryptor.ProcessBytes(readBuffer, 0, read, readBuffer, 0);
-				}
-				if (_decompressor != null) {
-					read = HandleDecompression(readBuffer, read);
-					readBuffer = _compressionBuffer;
-				}
-				WriteToInputBuffer(readBuffer, read);
-			}
 		}
-		var dataLength = ReadFromInputBuffer(buffer, offset, count);
-		return dataLength;
-	}
-	public async ValueTask<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken = default)
-	{
+
 		if (_inputBuffer.Count < count)
 		{
-			var readBuffer = _readBuffer;
+			FillInputBuffer();
+		}
+
+		return _inputBuffer.CopyTo(buffer.Slice(offset, count));
+	}
+
+	public async ValueTask<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken = default)
+	{
+		if (count <= 0)
+			return 0;
+
+		if (_inputBuffer.Count == 0 && _decompressor == null && count >= DirectReadWriteThreshold)
+		{
 			int read;
 			try
 			{
-				read = await _dataProvider.ReadAsync(readBuffer, 0, readBuffer.Length, cancellationToken).ConfigureAwait(false);
+				read = await _dataProvider.ReadAsync(buffer, offset, count, cancellationToken).ConfigureAwait(false);
 			}
 			catch (IOException)
 			{
 				IOFailed = true;
 				throw;
 			}
-			if (read != 0)
+
+			if (read > 0 && _decryptor != null)
 			{
-				if (_decryptor != null)
-				{
-					_decryptor.ProcessBytes(readBuffer, 0, read, readBuffer, 0);
-				}
-				if (_decompressor != null)
-				{
-					read = HandleDecompression(readBuffer, read);
-					readBuffer = _compressionBuffer;
-				}
-				WriteToInputBuffer(readBuffer, read);
+				_decryptor.ProcessBytes(buffer, offset, read, buffer, offset);
 			}
+			return read;
 		}
-		var dataLength = ReadFromInputBuffer(buffer, offset, count);
-		return dataLength;
+
+		if (_inputBuffer.Count < count)
+		{
+			await FillInputBufferAsync(cancellationToken).ConfigureAwait(false);
+		}
+
+		return _inputBuffer.CopyTo(buffer.AsSpan(offset, count));
 	}
 
-    public async ValueTask<int> ReadAsync(Memory<byte> buffer, int offset, int count, CancellationToken cancellationToken = default)
-    {
-        var rented = new byte[count];
-        try
-        {
-            var read = await ReadAsync(rented, 0, count, cancellationToken).ConfigureAwait(false);
-            rented.AsSpan(0, read).CopyTo(buffer.Span.Slice(offset, read));
-            return read;
-        }
-        finally { }
-    }
+	public async ValueTask<int> ReadAsync(Memory<byte> buffer, int offset, int count, CancellationToken cancellationToken = default)
+	{
+		if (count <= 0)
+			return 0;
+
+		var destination = buffer.Slice(offset, count);
+		if (_inputBuffer.Count == 0 && _decompressor == null && count >= DirectReadWriteThreshold
+			&& MemoryMarshal.TryGetArray(destination, out ArraySegment<byte> segment))
+		{
+			int read;
+			try
+			{
+				read = await _dataProvider.ReadAsync(segment.Array, segment.Offset, segment.Count, cancellationToken).ConfigureAwait(false);
+			}
+			catch (IOException)
+			{
+				IOFailed = true;
+				throw;
+			}
+
+			if (read > 0 && _decryptor != null)
+			{
+				_decryptor.ProcessBytes(segment.Array, segment.Offset, read, segment.Array, segment.Offset);
+			}
+			return read;
+		}
+
+		if (_inputBuffer.Count < count)
+		{
+			await FillInputBufferAsync(cancellationToken).ConfigureAwait(false);
+		}
+
+		return _inputBuffer.CopyTo(destination.Span);
+	}
 
 	public void Write(ReadOnlySpan<byte> buffer)
 	{
-		foreach (var b in buffer)
-			_outputBuffer.Enqueue(b);
+		if (buffer.IsEmpty)
+			return;
+
+		if (_compressor == null && _encryptor == null && _outputBuffer.Count == 0 && buffer.Length >= DirectReadWriteThreshold)
+		{
+			try
+			{
+				_dataProvider.Write(buffer);
+			}
+			catch (IOException)
+			{
+				IOFailed = true;
+				throw;
+			}
+			return;
+		}
+
+		_outputBuffer.Write(buffer);
 	}
 
 	public void Write(byte[] buffer, int offset, int count)
 	{
-		for (var i = 0; i < count; i++)
-			_outputBuffer.Enqueue(buffer[offset + i]);
+		if (buffer == null || count <= 0)
+			return;
+
+		if (_compressor == null && _encryptor == null && _outputBuffer.Count == 0 && count >= DirectReadWriteThreshold)
+		{
+			try
+			{
+				_dataProvider.Write(buffer, offset, count);
+			}
+			catch (IOException)
+			{
+				IOFailed = true;
+				throw;
+			}
+			return;
+		}
+
+		_outputBuffer.Write(buffer.AsSpan(offset, count));
 	}
 	public ValueTask WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken = default)
 	{
-		for (var i = 0; i < count; i++)
-			_outputBuffer.Enqueue(buffer[offset + i]);
+		if (buffer == null || count <= 0)
+			return ValueTask.CompletedTask;
+
+		if (_compressor == null && _encryptor == null && _outputBuffer.Count == 0 && count >= DirectReadWriteThreshold)
+		{
+			return WriteDirectAsync(buffer, offset, count, cancellationToken);
+		}
+
+		_outputBuffer.Write(buffer.AsSpan(offset, count));
 		return ValueTask.CompletedTask;
+
+		async ValueTask WriteDirectAsync(byte[] directBuffer, int directOffset, int directCount, CancellationToken directCancellationToken)
+		{
+			try
+			{
+				await _dataProvider.WriteAsync(directBuffer, directOffset, directCount, directCancellationToken).ConfigureAwait(false);
+			}
+			catch (IOException)
+			{
+				IOFailed = true;
+				throw;
+			}
+		}
 	}
 
 	public ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, int offset, int count, CancellationToken cancellationToken = default)
 	{
-		var span = buffer.Span.Slice(offset, count);
-		foreach (var b in span)
-			_outputBuffer.Enqueue(b);
-		return ValueTask2.CompletedTask;
+		if (count <= 0)
+			return ValueTask.CompletedTask;
+
+		if (_compressor == null && _encryptor == null && _outputBuffer.Count == 0 && count >= DirectReadWriteThreshold)
+		{
+			return WriteDirectAsync(buffer, offset, count, cancellationToken);
+		}
+
+		_outputBuffer.Write(buffer.Span.Slice(offset, count));
+		return ValueTask.CompletedTask;
+
+		async ValueTask WriteDirectAsync(ReadOnlyMemory<byte> directBuffer, int directOffset, int directCount, CancellationToken directCancellationToken)
+		{
+			try
+			{
+				await _dataProvider.WriteAsync(directBuffer, directOffset, directCount, directCancellationToken).ConfigureAwait(false);
+			}
+			catch (IOException)
+			{
+				IOFailed = true;
+				throw;
+			}
+		}
 	}
 
 	public void Flush()
 	{
-		var buffer = _outputBuffer.ToArray();
-		_outputBuffer.Clear();
-		var count = buffer.Length;
-		if (_compressor != null)
-		{
-			count = HandleCompression(buffer, count);
-			buffer = _compressionBuffer;
-		}
-		if (_encryptor != null)
-		{
-			_encryptor.ProcessBytes(buffer, 0, count, buffer, 0);
-		}
 		try
 		{
-			_dataProvider.Write(buffer, 0, count);
+			if (_compressor != null)
+			{
+				FlushCompressed();
+			}
+			else if (_outputBuffer.Count > 0)
+			{
+				FlushPlain();
+			}
+
 			_dataProvider.Flush();
 		}
 		catch (IOException)
@@ -212,21 +305,17 @@ sealed class FirebirdNetworkHandlingWrapper : IDataProvider, ITracksIOFailure
 	}
 	public async ValueTask FlushAsync(CancellationToken cancellationToken = default)
 	{
-		var buffer = _outputBuffer.ToArray();
-		_outputBuffer.Clear();
-		var count = buffer.Length;
-		if (_compressor != null)
-		{
-			count = HandleCompression(buffer, count);
-			buffer = _compressionBuffer;
-		}
-		if (_encryptor != null)
-		{
-			_encryptor.ProcessBytes(buffer, 0, count, buffer, 0);
-		}
 		try
 		{
-			await _dataProvider.WriteAsync(buffer, 0, count, cancellationToken).ConfigureAwait(false);
+			if (_compressor != null)
+			{
+				await FlushCompressedAsync(cancellationToken).ConfigureAwait(false);
+			}
+			else if (_outputBuffer.Count > 0)
+			{
+				await FlushPlainAsync(cancellationToken).ConfigureAwait(false);
+			}
+
 			await _dataProvider.FlushAsync(cancellationToken).ConfigureAwait(false);
 		}
 		catch (IOException)
@@ -249,30 +338,83 @@ sealed class FirebirdNetworkHandlingWrapper : IDataProvider, ITracksIOFailure
 		_decryptor = CreateCipher(key);
 	}
 
-	int ReadFromInputBuffer(byte[] buffer, int offset, int count)
+	void FillInputBuffer()
 	{
-		var read = Math.Min(count, _inputBuffer.Count);
-		for (var i = 0; i < read; i++)
+		try
 		{
-			buffer[offset + i] = _inputBuffer.Dequeue();
+			if (_decompressor == null)
+			{
+				_inputBuffer.EnsureFree(1);
+				_inputBuffer.GetWriteSegment(out var writeOffset, out var writeLength);
+				var toRead = Math.Min(writeLength, _readBuffer.Length);
+				var read = _dataProvider.Read(_inputBuffer.Buffer, writeOffset, toRead);
+				if (read <= 0)
+					return;
+
+				if (_decryptor != null)
+				{
+					_decryptor.ProcessBytes(_inputBuffer.Buffer, writeOffset, read, _inputBuffer.Buffer, writeOffset);
+				}
+				_inputBuffer.AdvanceWrite(read);
+			}
+			else
+			{
+				var read = _dataProvider.Read(_readBuffer, 0, _readBuffer.Length);
+				if (read <= 0)
+					return;
+
+				if (_decryptor != null)
+				{
+					_decryptor.ProcessBytes(_readBuffer, 0, read, _readBuffer, 0);
+				}
+				read = HandleDecompression(_readBuffer, read);
+				_inputBuffer.Write(_compressionBuffer.AsSpan(0, read));
+			}
 		}
-		return read;
+		catch (IOException)
+		{
+			IOFailed = true;
+			throw;
+		}
 	}
 
-	int ReadFromInputBuffer(Span<byte> buffer, int offset, int count)
+	async ValueTask FillInputBufferAsync(CancellationToken cancellationToken)
 	{
-		var read = Math.Min(count, _inputBuffer.Count);
-		for (var i = 0; i < read; i++) {
-			buffer[offset+i] = _inputBuffer.Dequeue();
-		}
-		return read;
-	}
-
-	void WriteToInputBuffer(byte[] data, int count)
-	{
-		for (var i = 0; i < count; i++)
+		try
 		{
-			_inputBuffer.Enqueue(data[i]);
+			if (_decompressor == null)
+			{
+				_inputBuffer.EnsureFree(1);
+				_inputBuffer.GetWriteSegment(out var writeOffset, out var writeLength);
+				var toRead = Math.Min(writeLength, _readBuffer.Length);
+				var read = await _dataProvider.ReadAsync(_inputBuffer.Buffer, writeOffset, toRead, cancellationToken).ConfigureAwait(false);
+				if (read <= 0)
+					return;
+
+				if (_decryptor != null)
+				{
+					_decryptor.ProcessBytes(_inputBuffer.Buffer, writeOffset, read, _inputBuffer.Buffer, writeOffset);
+				}
+				_inputBuffer.AdvanceWrite(read);
+			}
+			else
+			{
+				var read = await _dataProvider.ReadAsync(_readBuffer, 0, _readBuffer.Length, cancellationToken).ConfigureAwait(false);
+				if (read <= 0)
+					return;
+
+				if (_decryptor != null)
+				{
+					_decryptor.ProcessBytes(_readBuffer, 0, read, _readBuffer, 0);
+				}
+				read = HandleDecompression(_readBuffer, read);
+				_inputBuffer.Write(_compressionBuffer.AsSpan(0, read));
+			}
+		}
+		catch (IOException)
+		{
+			IOFailed = true;
+			throw;
 		}
 	}
 
@@ -299,46 +441,183 @@ sealed class FirebirdNetworkHandlingWrapper : IDataProvider, ITracksIOFailure
 		return _decompressor.NextOut;
 	}
 
-	int HandleCompression(byte[] buffer, int count)
-	{
-		_compressor.InputBuffer = buffer;
-		_compressor.NextOut = 0;
-		_compressor.NextIn = 0;
-		_compressor.AvailableBytesIn = count;
-		while (true)
-		{
-			_compressor.OutputBuffer = _compressionBuffer;
-			_compressor.AvailableBytesOut = _compressionBuffer.Length - _compressor.NextOut;
-			var rc = _compressor.Deflate(Ionic.Zlib.FlushType.None);
-			if (rc != Ionic.Zlib.ZlibConstants.Z_OK)
-				throw new IOException($"Error '{rc}' while compressing the data.");
-			if (_compressor.AvailableBytesIn > 0 || _compressor.AvailableBytesOut == 0)
-			{
-				ResizeBuffer(ref _compressionBuffer);
-				continue;
-			}
-			break;
-		}
-		while (true)
-		{
-			_compressor.OutputBuffer = _compressionBuffer;
-			_compressor.AvailableBytesOut = _compressionBuffer.Length - _compressor.NextOut;
-			var rc = _compressor.Deflate(Ionic.Zlib.FlushType.Sync);
-			if (rc != Ionic.Zlib.ZlibConstants.Z_OK)
-				throw new IOException($"Error '{rc}' while compressing the data.");
-			if (_compressor.AvailableBytesIn > 0 || _compressor.AvailableBytesOut == 0)
-			{
-				ResizeBuffer(ref _compressionBuffer);
-				continue;
-			}
-			break;
-		}
-		return _compressor.NextOut;
-	}
-
 	static void ResizeBuffer(ref byte[] buffer)
 	{
 		Array.Resize(ref buffer, buffer.Length * 2);
+	}
+
+	void FlushPlain()
+	{
+		_outputBuffer.GetReadSegments(out var off1, out var len1, out var off2, out var len2);
+
+		try
+		{
+			if (_encryptor != null)
+			{
+				if (len1 > 0)
+				{
+					_encryptor.ProcessBytes(_outputBuffer.Buffer, off1, len1, _outputBuffer.Buffer, off1);
+				}
+				if (len2 > 0)
+				{
+					_encryptor.ProcessBytes(_outputBuffer.Buffer, off2, len2, _outputBuffer.Buffer, off2);
+				}
+			}
+
+			if (len1 > 0)
+			{
+				_dataProvider.Write(_outputBuffer.Buffer, off1, len1);
+			}
+			if (len2 > 0)
+			{
+				_dataProvider.Write(_outputBuffer.Buffer, off2, len2);
+			}
+		}
+		finally
+		{
+			_outputBuffer.Consume(len1 + len2);
+		}
+	}
+
+	async ValueTask FlushPlainAsync(CancellationToken cancellationToken)
+	{
+		_outputBuffer.GetReadSegments(out var off1, out var len1, out var off2, out var len2);
+
+		try
+		{
+			if (_encryptor != null)
+			{
+				if (len1 > 0)
+				{
+					_encryptor.ProcessBytes(_outputBuffer.Buffer, off1, len1, _outputBuffer.Buffer, off1);
+				}
+				if (len2 > 0)
+				{
+					_encryptor.ProcessBytes(_outputBuffer.Buffer, off2, len2, _outputBuffer.Buffer, off2);
+				}
+			}
+
+			if (len1 > 0)
+			{
+				await _dataProvider.WriteAsync(_outputBuffer.Buffer, off1, len1, cancellationToken).ConfigureAwait(false);
+			}
+			if (len2 > 0)
+			{
+				await _dataProvider.WriteAsync(_outputBuffer.Buffer, off2, len2, cancellationToken).ConfigureAwait(false);
+			}
+		}
+		finally
+		{
+			_outputBuffer.Consume(len1 + len2);
+		}
+	}
+
+	void FlushCompressed()
+	{
+		_outputBuffer.GetReadSegments(out var off1, out var len1, out var off2, out var len2);
+		try
+		{
+			if (len1 > 0)
+			{
+				DeflateAndWrite(_outputBuffer.Buffer, off1, len1, Ionic.Zlib.FlushType.None);
+			}
+			if (len2 > 0)
+			{
+				DeflateAndWrite(_outputBuffer.Buffer, off2, len2, Ionic.Zlib.FlushType.None);
+			}
+			DeflateAndWrite(Array.Empty<byte>(), 0, 0, Ionic.Zlib.FlushType.Sync);
+		}
+		finally
+		{
+			_outputBuffer.Consume(len1 + len2);
+		}
+	}
+
+	async ValueTask FlushCompressedAsync(CancellationToken cancellationToken)
+	{
+		_outputBuffer.GetReadSegments(out var off1, out var len1, out var off2, out var len2);
+		try
+		{
+			if (len1 > 0)
+			{
+				await DeflateAndWriteAsync(_outputBuffer.Buffer, off1, len1, Ionic.Zlib.FlushType.None, cancellationToken).ConfigureAwait(false);
+			}
+			if (len2 > 0)
+			{
+				await DeflateAndWriteAsync(_outputBuffer.Buffer, off2, len2, Ionic.Zlib.FlushType.None, cancellationToken).ConfigureAwait(false);
+			}
+			await DeflateAndWriteAsync(Array.Empty<byte>(), 0, 0, Ionic.Zlib.FlushType.Sync, cancellationToken).ConfigureAwait(false);
+		}
+		finally
+		{
+			_outputBuffer.Consume(len1 + len2);
+		}
+	}
+
+	void DeflateAndWrite(byte[] input, int offset, int count, Ionic.Zlib.FlushType flushType)
+	{
+		_compressor.InputBuffer = input;
+		_compressor.NextIn = offset;
+		_compressor.AvailableBytesIn = count;
+
+		while (true)
+		{
+			_compressor.OutputBuffer = _compressionBuffer;
+			_compressor.NextOut = 0;
+			_compressor.AvailableBytesOut = _compressionBuffer.Length;
+			var rc = _compressor.Deflate(flushType);
+			if (rc != Ionic.Zlib.ZlibConstants.Z_OK)
+				throw new IOException($"Error '{rc}' while compressing the data.");
+
+			var produced = _compressor.NextOut;
+			if (produced > 0)
+			{
+				if (_encryptor != null)
+				{
+					_encryptor.ProcessBytes(_compressionBuffer, 0, produced, _compressionBuffer, 0);
+				}
+				_dataProvider.Write(_compressionBuffer, 0, produced);
+			}
+
+			if (_compressor.AvailableBytesIn > 0 || _compressor.AvailableBytesOut == 0)
+			{
+				continue;
+			}
+			break;
+		}
+	}
+
+	async ValueTask DeflateAndWriteAsync(byte[] input, int offset, int count, Ionic.Zlib.FlushType flushType, CancellationToken cancellationToken)
+	{
+		_compressor.InputBuffer = input;
+		_compressor.NextIn = offset;
+		_compressor.AvailableBytesIn = count;
+
+		while (true)
+		{
+			_compressor.OutputBuffer = _compressionBuffer;
+			_compressor.NextOut = 0;
+			_compressor.AvailableBytesOut = _compressionBuffer.Length;
+			var rc = _compressor.Deflate(flushType);
+			if (rc != Ionic.Zlib.ZlibConstants.Z_OK)
+				throw new IOException($"Error '{rc}' while compressing the data.");
+
+			var produced = _compressor.NextOut;
+			if (produced > 0)
+			{
+				if (_encryptor != null)
+				{
+					_encryptor.ProcessBytes(_compressionBuffer, 0, produced, _compressionBuffer, 0);
+				}
+				await _dataProvider.WriteAsync(_compressionBuffer, 0, produced, cancellationToken).ConfigureAwait(false);
+			}
+
+			if (_compressor.AvailableBytesIn > 0 || _compressor.AvailableBytesOut == 0)
+			{
+				continue;
+			}
+			break;
+		}
 	}
 
 	static Org.BouncyCastle.Crypto.Engines.RC4Engine CreateCipher(byte[] key)
@@ -346,5 +625,151 @@ sealed class FirebirdNetworkHandlingWrapper : IDataProvider, ITracksIOFailure
 		var cipher = new Org.BouncyCastle.Crypto.Engines.RC4Engine();
 		cipher.Init(default, new Org.BouncyCastle.Crypto.Parameters.KeyParameter(key));
 		return cipher;
+	}
+
+	sealed class ByteRingBuffer
+	{
+		byte[] _buffer;
+		int _head;
+		int _count;
+
+		public byte[] Buffer => _buffer;
+		public int Count => _count;
+
+		public ByteRingBuffer(int initialCapacity)
+		{
+			_buffer = ArrayPool<byte>.Shared.Rent(initialCapacity);
+			_head = 0;
+			_count = 0;
+		}
+
+		public void EnsureFree(int bytes)
+		{
+			if (bytes <= 0)
+				return;
+
+			var free = _buffer.Length - _count;
+			if (free >= bytes)
+				return;
+
+			Grow(_count + bytes);
+		}
+
+		void Grow(int requiredCapacity)
+		{
+			var newCapacity = _buffer.Length;
+			while (newCapacity < requiredCapacity)
+			{
+				newCapacity *= 2;
+			}
+
+				var newBuffer = ArrayPool<byte>.Shared.Rent(newCapacity);
+
+				GetReadSegments(out var off1, out var len1, out var off2, out var len2);
+				if (len1 > 0)
+				{
+					System.Buffer.BlockCopy(_buffer, off1, newBuffer, 0, len1);
+				}
+				if (len2 > 0)
+				{
+					System.Buffer.BlockCopy(_buffer, off2, newBuffer, len1, len2);
+				}
+
+				ArrayPool<byte>.Shared.Return(_buffer);
+				_buffer = newBuffer;
+				_head = 0;
+		}
+
+		public void Write(ReadOnlySpan<byte> src)
+		{
+			if (src.IsEmpty)
+				return;
+
+			EnsureFree(src.Length);
+
+			var tail = (_head + _count) % _buffer.Length;
+			var len1 = Math.Min(src.Length, _buffer.Length - tail);
+			src.Slice(0, len1).CopyTo(_buffer.AsSpan(tail, len1));
+
+			var len2 = src.Length - len1;
+			if (len2 > 0)
+			{
+				src.Slice(len1, len2).CopyTo(_buffer.AsSpan(0, len2));
+			}
+
+			_count += src.Length;
+		}
+
+		public int CopyTo(Span<byte> dst)
+		{
+			if (dst.IsEmpty || _count == 0)
+				return 0;
+
+			var toCopy = Math.Min(dst.Length, _count);
+			var len1 = Math.Min(toCopy, _buffer.Length - _head);
+			_buffer.AsSpan(_head, len1).CopyTo(dst);
+			var len2 = toCopy - len1;
+			if (len2 > 0)
+			{
+				_buffer.AsSpan(0, len2).CopyTo(dst.Slice(len1, len2));
+			}
+			Consume(toCopy);
+			return toCopy;
+		}
+
+		public void Consume(int bytes)
+		{
+			if (bytes <= 0)
+				return;
+
+			if (bytes > _count)
+				throw new ArgumentOutOfRangeException(nameof(bytes));
+
+			_head = (_head + bytes) % _buffer.Length;
+			_count -= bytes;
+			if (_count == 0)
+			{
+				_head = 0;
+			}
+		}
+
+		public void GetReadSegments(out int offset1, out int length1, out int offset2, out int length2)
+		{
+			if (_count == 0)
+			{
+				offset1 = offset2 = length1 = length2 = 0;
+				return;
+			}
+
+			offset1 = _head;
+			length1 = Math.Min(_count, _buffer.Length - _head);
+			offset2 = 0;
+			length2 = _count - length1;
+		}
+
+		public void GetWriteSegment(out int offset, out int length)
+		{
+			if (_count == _buffer.Length)
+			{
+				offset = 0;
+				length = 0;
+				return;
+			}
+
+			var tail = (_head + _count) % _buffer.Length;
+			offset = tail;
+			length = tail >= _head ? _buffer.Length - tail : _head - tail;
+		}
+
+		public void AdvanceWrite(int bytes)
+		{
+			if (bytes <= 0)
+				return;
+
+			if (bytes > _buffer.Length - _count)
+				throw new ArgumentOutOfRangeException(nameof(bytes));
+
+			_count += bytes;
+		}
 	}
 }

--- a/src/FirebirdSql.Data.FirebirdClient/Client/Managed/FirebirdNetworkHandlingWrapper.cs
+++ b/src/FirebirdSql.Data.FirebirdClient/Client/Managed/FirebirdNetworkHandlingWrapper.cs
@@ -87,6 +87,33 @@ sealed class FirebirdNetworkHandlingWrapper : IDataProvider, ITracksIOFailure
 		var dataLength = ReadFromInputBuffer(buffer, offset, count);
 		return dataLength;
 	}
+
+	public int Read(Span<byte> buffer, int offset, int count)
+	{
+		if (_inputBuffer.Count < count) {
+			var readBuffer = _readBuffer;
+			int read;
+			try {
+				read = _dataProvider.Read(readBuffer, 0, readBuffer.Length);
+			}
+			catch (IOException) {
+				IOFailed = true;
+				throw;
+			}
+			if (read != 0) {
+				if (_decryptor != null) {
+					_decryptor.ProcessBytes(readBuffer, 0, read, readBuffer, 0);
+				}
+				if (_decompressor != null) {
+					read = HandleDecompression(readBuffer, read);
+					readBuffer = _compressionBuffer;
+				}
+				WriteToInputBuffer(readBuffer, read);
+			}
+		}
+		var dataLength = ReadFromInputBuffer(buffer, offset, count);
+		return dataLength;
+	}
 	public async ValueTask<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken = default)
 	{
 		if (_inputBuffer.Count < count)
@@ -120,6 +147,24 @@ sealed class FirebirdNetworkHandlingWrapper : IDataProvider, ITracksIOFailure
 		return dataLength;
 	}
 
+    public async ValueTask<int> ReadAsync(Memory<byte> buffer, int offset, int count, CancellationToken cancellationToken = default)
+    {
+        var rented = new byte[count];
+        try
+        {
+            var read = await ReadAsync(rented, 0, count, cancellationToken).ConfigureAwait(false);
+            rented.AsSpan(0, read).CopyTo(buffer.Span.Slice(offset, read));
+            return read;
+        }
+        finally { }
+    }
+
+	public void Write(ReadOnlySpan<byte> buffer)
+	{
+		foreach (var b in buffer)
+			_outputBuffer.Enqueue(b);
+	}
+
 	public void Write(byte[] buffer, int offset, int count)
 	{
 		for (var i = 0; i < count; i++)
@@ -130,6 +175,14 @@ sealed class FirebirdNetworkHandlingWrapper : IDataProvider, ITracksIOFailure
 		for (var i = 0; i < count; i++)
 			_outputBuffer.Enqueue(buffer[offset + i]);
 		return ValueTask.CompletedTask;
+	}
+
+	public ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, int offset, int count, CancellationToken cancellationToken = default)
+	{
+		var span = buffer.Span.Slice(offset, count);
+		foreach (var b in span)
+			_outputBuffer.Enqueue(b);
+		return ValueTask2.CompletedTask;
 	}
 
 	public void Flush()
@@ -202,6 +255,15 @@ sealed class FirebirdNetworkHandlingWrapper : IDataProvider, ITracksIOFailure
 		for (var i = 0; i < read; i++)
 		{
 			buffer[offset + i] = _inputBuffer.Dequeue();
+		}
+		return read;
+	}
+
+	int ReadFromInputBuffer(Span<byte> buffer, int offset, int count)
+	{
+		var read = Math.Min(count, _inputBuffer.Count);
+		for (var i = 0; i < read; i++) {
+			buffer[offset+i] = _inputBuffer.Dequeue();
 		}
 		return read;
 	}

--- a/src/FirebirdSql.Data.FirebirdClient/Client/Managed/GdsConnection.cs
+++ b/src/FirebirdSql.Data.FirebirdClient/Client/Managed/GdsConnection.cs
@@ -359,19 +359,29 @@ internal sealed class GdsConnection
 
 	public void Disconnect()
 	{
+		_firebirdNetworkHandlingWrapper?.Dispose();
+		_firebirdNetworkHandlingWrapper = null;
+
 		if (_networkStream != null)
 		{
 			_networkStream.Dispose();
 			_networkStream = null;
 		}
+
+		Xdr = null;
 	}
 	public async ValueTask DisconnectAsync(CancellationToken cancellationToken = default)
 	{
+		_firebirdNetworkHandlingWrapper?.Dispose();
+		_firebirdNetworkHandlingWrapper = null;
+
 		if (_networkStream != null)
 		{
 			await _networkStream.DisposeAsync().ConfigureAwait(false);
 			_networkStream = null;
 		}
+
+		Xdr = null;
 	}
 
 	internal IResponse ProcessOperation(int operation)

--- a/src/FirebirdSql.Data.FirebirdClient/Client/Managed/IDataProvider.cs
+++ b/src/FirebirdSql.Data.FirebirdClient/Client/Managed/IDataProvider.cs
@@ -15,6 +15,7 @@
 
 //$Authors = Jiri Cincura (jiri@cincura.net)
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -23,10 +24,14 @@ namespace FirebirdSql.Data.Client.Managed;
 interface IDataProvider
 {
 	int Read(byte[] buffer, int offset, int count);
+	int Read(Span<byte> buffer, int offset, int count);
 	ValueTask<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken = default);
+	ValueTask<int> ReadAsync(Memory<byte> buffer, int offset, int count, CancellationToken cancellationToken = default);
 
+	void Write(ReadOnlySpan<byte> buffer);
 	void Write(byte[] buffer, int offset, int count);
 	ValueTask WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken = default);
+	ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, int offset, int count, CancellationToken cancellationToken = default);
 
 	void Flush();
 	ValueTask FlushAsync(CancellationToken cancellationToken = default);

--- a/src/FirebirdSql.Data.FirebirdClient/Client/Managed/IXdrReader.cs
+++ b/src/FirebirdSql.Data.FirebirdClient/Client/Managed/IXdrReader.cs
@@ -27,12 +27,18 @@ namespace FirebirdSql.Data.Client.Managed;
 interface IXdrReader
 {
 	byte[] ReadBytes(byte[] buffer, int count);
+	void ReadBytes(Span<byte> buffer, int count);
+	ValueTask ReadBytesAsync(Memory<byte> buffer, int count, CancellationToken cancellationToken = default);
 	ValueTask<byte[]> ReadBytesAsync(byte[] buffer, int count, CancellationToken cancellationToken = default);
 
 	byte[] ReadOpaque(int length);
+	void ReadOpaque(Span<byte> buffer, int length);
+	ValueTask ReadOpaqueAsync(Memory<byte> buffer, int length, CancellationToken cancellationToken = default);
 	ValueTask<byte[]> ReadOpaqueAsync(int length, CancellationToken cancellationToken = default);
 
 	byte[] ReadBuffer();
+	void ReadBuffer(Span<byte> buffer);
+	ValueTask ReadBufferAsync(Memory<byte> buffer, CancellationToken cancellationToken = default);
 	ValueTask<byte[]> ReadBufferAsync(CancellationToken cancellationToken = default);
 
 	string ReadString();

--- a/src/FirebirdSql.Data.FirebirdClient/Client/Managed/IXdrWriter.cs
+++ b/src/FirebirdSql.Data.FirebirdClient/Client/Managed/IXdrWriter.cs
@@ -28,25 +28,36 @@ interface IXdrWriter
 	void Flush();
 	ValueTask FlushAsync(CancellationToken cancellationToken = default);
 
+	void WriteBytes(ReadOnlySpan<byte> buffer);
 	void WriteBytes(byte[] buffer, int count);
 	ValueTask WriteBytesAsync(byte[] buffer, int count, CancellationToken cancellationToken = default);
 
 	void WriteOpaque(byte[] buffer);
+	void WriteOpaque(ReadOnlySpan<byte> buffer);
+	ValueTask WriteOpaqueAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default);
 	ValueTask WriteOpaqueAsync(byte[] buffer, CancellationToken cancellationToken = default);
 
 	void WriteOpaque(byte[] buffer, int length);
+	void WriteOpaque(ReadOnlySpan<byte> buffer, int length);
 	ValueTask WriteOpaqueAsync(byte[] buffer, int length, CancellationToken cancellationToken = default);
+	ValueTask WriteOpaqueAsync(ReadOnlyMemory<byte> buffer, int length, CancellationToken cancellationToken = default);
 
 	void WriteBuffer(byte[] buffer);
+	void WriteBuffer(ReadOnlySpan<byte> buffer);
+	ValueTask WriteBufferAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default);
 	ValueTask WriteBufferAsync(byte[] buffer, CancellationToken cancellationToken = default);
 
 	void WriteBuffer(byte[] buffer, int length);
 	ValueTask WriteBufferAsync(byte[] buffer, int length, CancellationToken cancellationToken = default);
 
 	void WriteBlobBuffer(byte[] buffer);
+	void WriteBlobBuffer(ReadOnlySpan<byte> buffer);
+	ValueTask WriteBlobBufferAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default);
 	ValueTask WriteBlobBufferAsync(byte[] buffer, CancellationToken cancellationToken = default);
 
 	void WriteTyped(int type, byte[] buffer);
+	void WriteTyped(int type, ReadOnlySpan<byte> buffer);
+	ValueTask WriteTypedAsync(int type, ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default);
 	ValueTask WriteTypedAsync(int type, byte[] buffer, CancellationToken cancellationToken = default);
 
 	void Write(string value);

--- a/src/FirebirdSql.Data.FirebirdClient/Client/Managed/XdrReaderWriter.cs
+++ b/src/FirebirdSql.Data.FirebirdClient/Client/Managed/XdrReaderWriter.cs
@@ -20,6 +20,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Numerics;
+using System.Buffers;
 using System.Threading;
 using System.Threading.Tasks;
 using FirebirdSql.Data.Common;
@@ -33,13 +34,16 @@ sealed class XdrReaderWriter : IXdrReader, IXdrWriter
 	readonly Charset _charset;
 
 	byte[] _smallBuffer;
+	byte[] _smallBuffer8;
+	const int StackallocThreshold = 1024;
 
 	public XdrReaderWriter(IDataProvider dataProvider, Charset charset)
 	{
 		_dataProvider = dataProvider;
 		_charset = charset;
 
-		_smallBuffer = new byte[8];
+		_smallBuffer = new byte[16];
+		_smallBuffer8 = new byte[8];
 	}
 
 	public XdrReaderWriter(IDataProvider dataProvider)
@@ -69,6 +73,27 @@ sealed class XdrReaderWriter : IXdrReader, IXdrWriter
 		}
 		return buffer;
 	}
+
+	public void ReadBytes(Span<byte> dst, int count)
+	{
+		if (count > 0)
+		{
+			var toRead = count;
+			var currentlyRead = -1;
+			while (toRead > 0 && currentlyRead != 0)
+			{
+				toRead -= (currentlyRead = _dataProvider.Read(dst, count - toRead, toRead));
+			}
+			if (currentlyRead == 0)
+			{
+				if (_dataProvider is ITracksIOFailure tracksIOFailure)
+				{
+					tracksIOFailure.IOFailed = true;
+				}
+				throw new IOException($"Missing {toRead} bytes to fill total {count}.");
+			}
+		}
+	}
 	public async ValueTask<byte[]> ReadBytesAsync(byte[] buffer, int count, CancellationToken cancellationToken = default)
 	{
 		if (count > 0)
@@ -91,28 +116,79 @@ sealed class XdrReaderWriter : IXdrReader, IXdrWriter
 		return buffer;
 	}
 
+    public async ValueTask ReadBytesAsync(Memory<byte> buffer, int count, CancellationToken cancellationToken = default)
+    {
+        if (count <= 0)
+            return;
+        var toRead = count;
+        var offset = 0;
+        while (toRead > 0)
+        {
+            var chunk = await _dataProvider.ReadAsync(buffer.Slice(offset, toRead), 0, toRead, cancellationToken).ConfigureAwait(false);
+            if (chunk == 0)
+            {
+                if (_dataProvider is ITracksIOFailure tracksIOFailure)
+                {
+                    tracksIOFailure.IOFailed = true;
+                }
+                throw new IOException($"Missing {toRead} bytes to fill total {count}.");
+            }
+            offset += chunk;
+            toRead -= chunk;
+        }
+    }
+
 	public byte[] ReadOpaque(int length)
 	{
-		var buffer = new byte[length];
+		var buffer = length > 0 ? new byte[length] : Array.Empty<byte>();
 		ReadBytes(buffer, length);
 		ReadPad((4 - length) & 3);
 		return buffer;
 	}
+
+	public void ReadOpaque(Span<byte> dst, int length)
+	{
+		ReadBytes(dst, length);
+		ReadPad((4 - length) & 3);
+	}
+
 	public async ValueTask<byte[]> ReadOpaqueAsync(int length, CancellationToken cancellationToken = default)
 	{
-		var buffer = new byte[length];
+		var buffer = length > 0 ? new byte[length] : Array.Empty<byte>();
 		await ReadBytesAsync(buffer, length, cancellationToken).ConfigureAwait(false);
 		await ReadPadAsync((4 - length) & 3, cancellationToken).ConfigureAwait(false);
 		return buffer;
+	}
+
+	public async ValueTask ReadOpaqueAsync(Memory<byte> buffer, int length, CancellationToken cancellationToken = default)
+	{
+		if (length <= 0)
+			return;
+		await ReadBytesAsync(buffer, length, cancellationToken).ConfigureAwait(false);
+		await ReadPadAsync((4 - length) & 3, cancellationToken).ConfigureAwait(false);
 	}
 
 	public byte[] ReadBuffer()
 	{
 		return ReadOpaque((ushort)ReadInt32());
 	}
+
+	public void ReadBuffer(Span<byte> dst)
+	{
+		ReadOpaque(dst, (ushort)ReadInt32());
+	}
+
 	public async ValueTask<byte[]> ReadBufferAsync(CancellationToken cancellationToken = default)
 	{
 		return await ReadOpaqueAsync((ushort)await ReadInt32Async(cancellationToken).ConfigureAwait(false), cancellationToken).ConfigureAwait(false);
+	}
+
+	public async ValueTask ReadBufferAsync(Memory<byte> dst, CancellationToken cancellationToken = default)
+	{
+		var length = (ushort)await ReadInt32Async(cancellationToken).ConfigureAwait(false);
+		if (dst.Length < length)
+			throw new IOException($"Destination too small. Need {length}, have {dst.Length}.");
+		await ReadOpaqueAsync(dst, length, cancellationToken).ConfigureAwait(false);
 	}
 
 	public string ReadString()
@@ -144,13 +220,44 @@ sealed class XdrReaderWriter : IXdrReader, IXdrWriter
 
 	public string ReadString(Charset charset, int length)
 	{
-		var buffer = ReadOpaque(length);
-		return charset.GetString(buffer, 0, buffer.Length);
+		if (length <= 0)
+			return string.Empty;
+		if (length <= StackallocThreshold)
+		{
+			Span<byte> buffer = stackalloc byte[length];
+			ReadOpaque(buffer, length);
+			return charset.GetString(buffer);
+		}
+		else
+		{
+			var rented = ArrayPool<byte>.Shared.Rent(length);
+			try
+			{
+				ReadBytes(rented, length);
+				ReadPad((4 - length) & 3);
+				return charset.GetString(rented.AsSpan(0, length));
+			}
+			finally
+			{
+				ArrayPool<byte>.Shared.Return(rented);
+			}
+		}
 	}
 	public async ValueTask<string> ReadStringAsync(Charset charset, int length, CancellationToken cancellationToken = default)
 	{
-		var buffer = await ReadOpaqueAsync(length, cancellationToken).ConfigureAwait(false);
-		return charset.GetString(buffer, 0, buffer.Length);
+		if (length <= 0)
+			return string.Empty;
+		var rented = ArrayPool<byte>.Shared.Rent(length);
+		try
+		{
+			await ReadBytesAsync(rented, length, cancellationToken).ConfigureAwait(false);
+			await ReadPadAsync((4 - length) & 3, cancellationToken).ConfigureAwait(false);
+			return charset.GetString(rented.AsSpan(0, length));
+		}
+		finally
+		{
+			ArrayPool<byte>.Shared.Return(rented);
+		}
 	}
 
 	public short ReadInt16()
@@ -164,8 +271,9 @@ sealed class XdrReaderWriter : IXdrReader, IXdrWriter
 
 	public int ReadInt32()
 	{
-		ReadBytes(_smallBuffer, 4);
-		return TypeDecoder.DecodeInt32(_smallBuffer);
+		Span<byte> bytes = stackalloc byte[4];
+		ReadBytes(bytes, 4);
+		return TypeDecoder.DecodeInt32(bytes);
 	}
 	public async ValueTask<int> ReadInt32Async(CancellationToken cancellationToken = default)
 	{
@@ -175,8 +283,9 @@ sealed class XdrReaderWriter : IXdrReader, IXdrWriter
 
 	public long ReadInt64()
 	{
-		ReadBytes(_smallBuffer, 8);
-		return TypeDecoder.DecodeInt64(_smallBuffer);
+		Span<byte> bytes = stackalloc byte[8];
+		ReadBytes(bytes, 8);
+		return TypeDecoder.DecodeInt64(bytes);
 	}
 	public async ValueTask<long> ReadInt64Async(CancellationToken cancellationToken = default)
 	{
@@ -192,7 +301,9 @@ sealed class XdrReaderWriter : IXdrReader, IXdrWriter
 		}
 		else
 		{
-			return TypeDecoder.DecodeGuid(ReadOpaque(16));
+			Span<byte> buf = stackalloc byte[16];
+			ReadOpaque(buf, 16);
+			return TypeDecoder.DecodeGuidSpan(buf);
 		}
 	}
 	public async ValueTask<Guid> ReadGuidAsync(int sqlType, CancellationToken cancellationToken = default)
@@ -201,28 +312,29 @@ sealed class XdrReaderWriter : IXdrReader, IXdrWriter
 		{
 			return TypeDecoder.DecodeGuid(await ReadBufferAsync(cancellationToken).ConfigureAwait(false));
 		}
-		else
-		{
-			return TypeDecoder.DecodeGuid(await ReadOpaqueAsync(16, cancellationToken).ConfigureAwait(false));
+	else
+		{			
+			await ReadBytesAsync(_smallBuffer, 16, cancellationToken).ConfigureAwait(false);
+			return TypeDecoder.DecodeGuid(_smallBuffer);			
 		}
 	}
 
 	public float ReadSingle()
 	{
-		return BitConverter.ToSingle(BitConverter.GetBytes(ReadInt32()), 0);
+		return BitConverter.Int32BitsToSingle(ReadInt32());
 	}
 	public async ValueTask<float> ReadSingleAsync(CancellationToken cancellationToken = default)
 	{
-		return BitConverter.ToSingle(BitConverter.GetBytes(await ReadInt32Async(cancellationToken).ConfigureAwait(false)), 0);
+		return BitConverter.Int32BitsToSingle(await ReadInt32Async(cancellationToken).ConfigureAwait(false));
 	}
 
 	public double ReadDouble()
 	{
-		return BitConverter.ToDouble(BitConverter.GetBytes(ReadInt64()), 0);
+		return BitConverter.Int64BitsToDouble(ReadInt64());
 	}
 	public async ValueTask<double> ReadDoubleAsync(CancellationToken cancellationToken = default)
 	{
-		return BitConverter.ToDouble(BitConverter.GetBytes(await ReadInt64Async(cancellationToken).ConfigureAwait(false)), 0);
+		return BitConverter.Int64BitsToDouble(await ReadInt64Async(cancellationToken).ConfigureAwait(false));
 	}
 
 	public DateTime ReadDateTime()
@@ -299,11 +411,14 @@ sealed class XdrReaderWriter : IXdrReader, IXdrWriter
 
 	public bool ReadBoolean()
 	{
-		return TypeDecoder.DecodeBoolean(ReadOpaque(1));
+		Span<byte> bytes = stackalloc byte[4];
+		ReadBytes(bytes, 4);
+		return TypeDecoder.DecodeBoolean(bytes);
 	}
 	public async ValueTask<bool> ReadBooleanAsync(CancellationToken cancellationToken = default)
 	{
-		return TypeDecoder.DecodeBoolean(await ReadOpaqueAsync(1, cancellationToken).ConfigureAwait(false));
+		await ReadBytesAsync(_smallBuffer, 4, cancellationToken).ConfigureAwait(false);
+		return TypeDecoder.DecodeBoolean(_smallBuffer);
 	}
 
 	public FbZonedDateTime ReadZonedDateTime(bool isExtended)
@@ -330,29 +445,35 @@ sealed class XdrReaderWriter : IXdrReader, IXdrWriter
 
 	public FbDecFloat ReadDec16()
 	{
-		return TypeDecoder.DecodeDec16(ReadOpaque(8));
+		ReadBytes(_smallBuffer8, 8);
+		return TypeDecoder.DecodeDec16(_smallBuffer8);
 	}
 	public async ValueTask<FbDecFloat> ReadDec16Async(CancellationToken cancellationToken = default)
 	{
-		return TypeDecoder.DecodeDec16(await ReadOpaqueAsync(8, cancellationToken).ConfigureAwait(false));
+		await ReadBytesAsync(_smallBuffer8, 8, cancellationToken).ConfigureAwait(false);
+		return TypeDecoder.DecodeDec16(_smallBuffer8);
 	}
 
 	public FbDecFloat ReadDec34()
 	{
-		return TypeDecoder.DecodeDec34(ReadOpaque(16));
+		ReadBytes(_smallBuffer, 16);
+		return TypeDecoder.DecodeDec34(_smallBuffer);
 	}
 	public async ValueTask<FbDecFloat> ReadDec34Async(CancellationToken cancellationToken = default)
 	{
-		return TypeDecoder.DecodeDec34(await ReadOpaqueAsync(16, cancellationToken).ConfigureAwait(false));
+		await ReadBytesAsync(_smallBuffer, 16, cancellationToken).ConfigureAwait(false);
+		return TypeDecoder.DecodeDec34(_smallBuffer);
 	}
 
 	public BigInteger ReadInt128()
 	{
-		return TypeDecoder.DecodeInt128(ReadOpaque(16));
+		ReadBytes(_smallBuffer, 16);
+		return TypeDecoder.DecodeInt128(_smallBuffer);
 	}
 	public async ValueTask<BigInteger> ReadInt128Async(CancellationToken cancellationToken = default)
 	{
-		return TypeDecoder.DecodeInt128(await ReadOpaqueAsync(16, cancellationToken).ConfigureAwait(false));
+		await ReadBytesAsync(_smallBuffer, 16, cancellationToken).ConfigureAwait(false);
+		return TypeDecoder.DecodeInt128(_smallBuffer);
 	}
 
 	public IscException ReadStatusVector()
@@ -480,6 +601,11 @@ sealed class XdrReaderWriter : IXdrReader, IXdrWriter
 		return _dataProvider.FlushAsync(cancellationToken);
 	}
 
+	public void WriteBytes(ReadOnlySpan<byte> buffer)
+	{
+		_dataProvider.Write(buffer);
+	}
+
 	public void WriteBytes(byte[] buffer, int count)
 	{
 		_dataProvider.Write(buffer, 0, count);
@@ -493,29 +619,75 @@ sealed class XdrReaderWriter : IXdrReader, IXdrWriter
 	{
 		WriteOpaque(buffer, buffer.Length);
 	}
+
 	public ValueTask WriteOpaqueAsync(byte[] buffer, CancellationToken cancellationToken = default)
 	{
 		return WriteOpaqueAsync(buffer, buffer.Length, cancellationToken);
 	}
 
-	public void WriteOpaque(byte[] buffer, int length)
+    public void WriteOpaque(byte[] buffer, int length)
+    {
+        if (buffer != null && length > 0)
+        {
+            _dataProvider.Write(buffer, 0, buffer.Length);
+            WriteFill(length - buffer.Length);
+            WritePad((4 - length) & 3);
+        }
+    }
+
+    public void WriteOpaque(ReadOnlySpan<byte> buffer, int length)
+    {
+        if (length > 0)
+        {
+            if (!buffer.IsEmpty)
+            {
+                _dataProvider.Write(buffer);
+            }
+            WriteFill(length - buffer.Length);
+            WritePad((4 - length) & 3);
+        }
+    }
+
+	public void WriteOpaque(ReadOnlySpan<byte> buffer)
 	{
-		if (buffer != null && length > 0)
-		{
-			_dataProvider.Write(buffer, 0, buffer.Length);
-			WriteFill(length - buffer.Length);
+		var length = buffer.Length;
+		if (length > 0) {
+			_dataProvider.Write(buffer);
 			WritePad((4 - length) & 3);
 		}
 	}
-	public async ValueTask WriteOpaqueAsync(byte[] buffer, int length, CancellationToken cancellationToken = default)
-	{
-		if (buffer != null && length > 0)
-		{
-			await _dataProvider.WriteAsync(buffer, 0, buffer.Length, cancellationToken).ConfigureAwait(false);
-			await WriteFillAsync(length - buffer.Length, cancellationToken).ConfigureAwait(false);
-			await WritePadAsync((4 - length) & 3, cancellationToken).ConfigureAwait(false);
-		}
-	}
+    public async ValueTask WriteOpaqueAsync(byte[] buffer, int length, CancellationToken cancellationToken = default)
+    {
+        if (buffer != null && length > 0)
+        {
+            await _dataProvider.WriteAsync(buffer, 0, buffer.Length, cancellationToken).ConfigureAwait(false);
+            await WriteFillAsync(length - buffer.Length, cancellationToken).ConfigureAwait(false);
+            await WritePadAsync((4 - length) & 3, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    public async ValueTask WriteOpaqueAsync(ReadOnlyMemory<byte> buffer, int length, CancellationToken cancellationToken = default)
+    {
+        if (length > 0)
+        {
+            if (buffer.Length > 0)
+            {
+                await _dataProvider.WriteAsync(buffer, 0, buffer.Length, cancellationToken).ConfigureAwait(false);
+            }
+            await WriteFillAsync(length - buffer.Length, cancellationToken).ConfigureAwait(false);
+            await WritePadAsync((4 - length) & 3, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    public async ValueTask WriteOpaqueAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+    {
+        var length = buffer.Length;
+        if (length > 0)
+        {
+            await _dataProvider.WriteAsync(buffer, 0, length, cancellationToken).ConfigureAwait(false);
+            await WritePadAsync((4 - length) & 3, cancellationToken).ConfigureAwait(false);
+        }
+    }
 
 	public void WriteBuffer(byte[] buffer)
 	{
@@ -526,12 +698,34 @@ sealed class XdrReaderWriter : IXdrReader, IXdrWriter
 		return WriteBufferAsync(buffer, buffer?.Length ?? 0, cancellationToken);
 	}
 
+    public async ValueTask WriteBufferAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+    {
+        var length = buffer.Length;
+        await WriteAsync(length, cancellationToken).ConfigureAwait(false);
+        if (length > 0)
+        {
+            await _dataProvider.WriteAsync(buffer, 0, length, cancellationToken).ConfigureAwait(false);
+            await WritePadAsync((4 - length) & 3, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
 	public void WriteBuffer(byte[] buffer, int length)
 	{
 		Write(length);
 		if (buffer != null && length > 0)
 		{
 			_dataProvider.Write(buffer, 0, length);
+			WritePad((4 - length) & 3);
+		}
+	}
+
+	public void WriteBuffer(ReadOnlySpan<byte> buffer)
+	{
+		var length = buffer.Length;
+		Write(length);
+		if (length > 0)
+		{
+			_dataProvider.Write(buffer);
 			WritePad((4 - length) & 3);
 		}
 	}
@@ -552,8 +746,24 @@ sealed class XdrReaderWriter : IXdrReader, IXdrWriter
 			throw new IOException("Blob buffer too big.");
 		Write(length + 2);
 		Write(length + 2);  //bizarre but true! three copies of the length
-		_dataProvider.Write(new[] { (byte)((length >> 0) & 0xff), (byte)((length >> 8) & 0xff) }, 0, 2);
+		Span<byte> lengthBytes = stackalloc byte[2];
+		lengthBytes[0] = (byte)((length >> 0) & 0xff);
+		lengthBytes[1] = (byte)((length >> 8) & 0xff);
+		_dataProvider.Write(lengthBytes);
 		_dataProvider.Write(buffer, 0, length);
+		WritePad((4 - length + 2) & 3);
+	}
+
+	public void WriteBlobBuffer(ReadOnlySpan<byte> buffer)
+	{
+		var length = buffer.Length; // 2 for short for buffer length
+		if (length > short.MaxValue)
+			throw new IOException("Blob buffer too big.");
+		Write(length + 2);
+		Write(length + 2);  //bizarre but true! three copies of the length
+		Span<byte> lengthBytes = [(byte)((length >> 0) & 0xff), (byte)((length >> 8) & 0xff)];
+		_dataProvider.Write(lengthBytes);
+		_dataProvider.Write(buffer);
 		WritePad((4 - length + 2) & 3);
 	}
 	public async ValueTask WriteBlobBufferAsync(byte[] buffer, CancellationToken cancellationToken = default)
@@ -563,26 +773,68 @@ sealed class XdrReaderWriter : IXdrReader, IXdrWriter
 			throw new IOException("Blob buffer too big.");
 		await WriteAsync(length + 2, cancellationToken).ConfigureAwait(false);
 		await WriteAsync(length + 2, cancellationToken).ConfigureAwait(false);  //bizarre but true! three copies of the length
-		await _dataProvider.WriteAsync(new[] { (byte)((length >> 0) & 0xff), (byte)((length >> 8) & 0xff) }, 0, 2, cancellationToken).ConfigureAwait(false);
+		var rented = ArrayPool<byte>.Shared.Rent(2);
+		try
+		{
+			rented[0] = (byte)((length >> 0) & 0xff);
+			rented[1] = (byte)((length >> 8) & 0xff);
+			await _dataProvider.WriteAsync(rented, 0, 2, cancellationToken).ConfigureAwait(false);
+		}
+		finally
+		{
+			ArrayPool<byte>.Shared.Return(rented);
+		}
 		await _dataProvider.WriteAsync(buffer, 0, length, cancellationToken).ConfigureAwait(false);
 		await WritePadAsync((4 - length + 2) & 3, cancellationToken).ConfigureAwait(false);
 	}
 
+    public async ValueTask WriteBlobBufferAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+    {
+        var length = buffer.Length; // 2 for short for buffer length
+        if (length > short.MaxValue)
+            throw new IOException("Blob buffer too big.");
+        await WriteAsync(length + 2, cancellationToken).ConfigureAwait(false);
+        await WriteAsync(length + 2, cancellationToken).ConfigureAwait(false);  // three copies of the length
+        Span<byte> lengthBytes = stackalloc byte[2];
+        lengthBytes[0] = (byte)((length >> 0) & 0xff);
+        lengthBytes[1] = (byte)((length >> 8) & 0xff);
+        _dataProvider.Write(lengthBytes);
+        await _dataProvider.WriteAsync(buffer, 0, length, cancellationToken).ConfigureAwait(false);
+        await WritePadAsync((4 - length + 2) & 3, cancellationToken).ConfigureAwait(false);
+    }
+
 	public void WriteTyped(int type, byte[] buffer)
 	{
+		Span<byte> typeByte = stackalloc byte[1];
 		int length;
 		if (buffer == null)
 		{
 			Write(1);
-			_dataProvider.Write(new[] { (byte)type }, 0, 1);
+			typeByte[0] = (byte)type;
+			_dataProvider.Write(typeByte);
 			length = 1;
 		}
 		else
 		{
 			length = buffer.Length + 1;
 			Write(length);
-			_dataProvider.Write(new[] { (byte)type }, 0, 1);
+			typeByte[0] = (byte)type;
+			_dataProvider.Write(typeByte);
 			_dataProvider.Write(buffer, 0, buffer.Length);
+		}
+		WritePad((4 - length) & 3);
+	}
+
+	public void WriteTyped(int type, ReadOnlySpan<byte> buffer)
+	{
+		Span<byte> typeByte = stackalloc byte[1];
+		var length = buffer.Length + 1;
+		Write(length);
+		typeByte[0] = (byte)type;
+		_dataProvider.Write(typeByte);
+		if (!buffer.IsEmpty)
+		{
+			_dataProvider.Write(buffer);
 		}
 		WritePad((4 - length) & 3);
 	}
@@ -592,28 +844,121 @@ sealed class XdrReaderWriter : IXdrReader, IXdrWriter
 		if (buffer == null)
 		{
 			await WriteAsync(1, cancellationToken).ConfigureAwait(false);
-			await _dataProvider.WriteAsync(new[] { (byte)type }, 0, 1, cancellationToken).ConfigureAwait(false);
+			var rented = ArrayPool<byte>.Shared.Rent(1);
+			try
+			{
+				rented[0] = (byte)type;
+				await _dataProvider.WriteAsync(rented, 0, 1, cancellationToken).ConfigureAwait(false);
+			}
+			finally
+			{
+				ArrayPool<byte>.Shared.Return(rented);
+			}
 			length = 1;
 		}
 		else
 		{
 			length = buffer.Length + 1;
 			await WriteAsync(length, cancellationToken).ConfigureAwait(false);
-			await _dataProvider.WriteAsync(new[] { (byte)type }, 0, 1, cancellationToken).ConfigureAwait(false);
+			var rented = ArrayPool<byte>.Shared.Rent(1);
+			try
+			{
+				rented[0] = (byte)type;
+				await _dataProvider.WriteAsync(rented, 0, 1, cancellationToken).ConfigureAwait(false);
+			}
+			finally
+			{
+				ArrayPool<byte>.Shared.Return(rented);
+			}
 			await _dataProvider.WriteAsync(buffer, 0, buffer.Length, cancellationToken).ConfigureAwait(false);
+		}
+		await WritePadAsync((4 - length) & 3, cancellationToken).ConfigureAwait(false);
+	}
+
+	public async ValueTask WriteTypedAsync(int type, ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+	{
+		int length;
+		if (buffer.Length == 0)
+		{
+			await WriteAsync(1, cancellationToken).ConfigureAwait(false);
+			var rented = ArrayPool<byte>.Shared.Rent(1);
+			try
+			{
+				rented[0] = (byte)type;
+				await _dataProvider.WriteAsync(rented, 0, 1, cancellationToken).ConfigureAwait(false);
+			}
+			finally
+			{
+				ArrayPool<byte>.Shared.Return(rented);
+			}
+			length = 1;
+		}
+		else
+		{
+			length = buffer.Length + 1;
+			await WriteAsync(length, cancellationToken).ConfigureAwait(false);
+			var rented = ArrayPool<byte>.Shared.Rent(1);
+			try
+			{
+				rented[0] = (byte)type;
+				await _dataProvider.WriteAsync(rented, 0, 1, cancellationToken).ConfigureAwait(false);
+			}
+			finally
+			{
+				ArrayPool<byte>.Shared.Return(rented);
+			}
+        await _dataProvider.WriteAsync(buffer, 0, buffer.Length, cancellationToken).ConfigureAwait(false);
 		}
 		await WritePadAsync((4 - length) & 3, cancellationToken).ConfigureAwait(false);
 	}
 
 	public void Write(string value)
 	{
-		var buffer = _charset.GetBytes(value);
-		WriteBuffer(buffer, buffer.Length);
+		if (string.IsNullOrEmpty(value))
+		{
+			WriteBuffer(ReadOnlySpan<byte>.Empty);
+			return;
+		}
+		var encoding = _charset.Encoding;
+		var maxBytes = encoding.GetMaxByteCount(value.Length);
+		if (maxBytes <= StackallocThreshold)
+		{
+			Span<byte> span = stackalloc byte[maxBytes];
+			var written = encoding.GetBytes(value.AsSpan(), span);
+			WriteBuffer(span[..written]);
+		}
+		else
+		{
+			var rented = ArrayPool<byte>.Shared.Rent(maxBytes);
+			try
+			{
+				var written = encoding.GetBytes(value.AsSpan(), rented.AsSpan());
+				WriteBuffer(rented.AsSpan(0, written));
+			}
+			finally
+			{
+				ArrayPool<byte>.Shared.Return(rented);
+			}
+		}
 	}
 	public ValueTask WriteAsync(string value, CancellationToken cancellationToken = default)
 	{
-		var buffer = _charset.GetBytes(value);
-		return WriteBufferAsync(buffer, buffer.Length, cancellationToken);
+		if (string.IsNullOrEmpty(value))
+		{
+			return WriteBufferAsync(Array.Empty<byte>(), 0, cancellationToken);
+		}
+		var encoding = _charset.Encoding;
+		var byteCount = encoding.GetByteCount(value);
+		var rented = ArrayPool<byte>.Shared.Rent(byteCount);
+		var written = encoding.GetBytes(value, 0, value.Length, rented, 0);
+		var task = WriteBufferAsync(rented, written, cancellationToken);
+		return ReturnAfter(task, rented);
+	}
+
+	static async ValueTask ReturnAfter(ValueTask writeTask, byte[] rented)
+	{
+		try { await writeTask.ConfigureAwait(false); }
+		finally { ArrayPool<byte>.Shared.Return(rented); }
 	}
 
 	public void Write(short value)
@@ -627,42 +972,50 @@ sealed class XdrReaderWriter : IXdrReader, IXdrWriter
 
 	public void Write(int value)
 	{
-		_dataProvider.Write(TypeEncoder.EncodeInt32(value), 0, 4);
+		Span<byte> bytes = stackalloc byte[4];
+		TypeEncoder.EncodeInt32(value, bytes);
+		_dataProvider.Write(bytes);
 	}
 	public ValueTask WriteAsync(int value, CancellationToken cancellationToken = default)
 	{
-		return _dataProvider.WriteAsync(TypeEncoder.EncodeInt32(value), 0, 4, cancellationToken);
+		var rented = ArrayPool<byte>.Shared.Rent(4);
+		Span<byte> span = rented;
+		TypeEncoder.EncodeInt32(value, span);
+		var task = _dataProvider.WriteAsync(rented, 0, 4, cancellationToken);
+		return ReturnAfter(task, rented);
 	}
 
 	public void Write(long value)
 	{
-		_dataProvider.Write(TypeEncoder.EncodeInt64(value), 0, 8);
+		Span<byte> bytes = stackalloc byte[8];
+		TypeEncoder.EncodeInt64(value, bytes);
+		_dataProvider.Write(bytes);
 	}
 	public ValueTask WriteAsync(long value, CancellationToken cancellationToken = default)
 	{
-		return _dataProvider.WriteAsync(TypeEncoder.EncodeInt64(value), 0, 8, cancellationToken);
+		var rented = ArrayPool<byte>.Shared.Rent(8);
+		Span<byte> span = rented;
+		TypeEncoder.EncodeInt64(value, span);
+		var task = _dataProvider.WriteAsync(rented, 0, 8, cancellationToken);
+		return ReturnAfter(task, rented);
 	}
 
 	public void Write(float value)
 	{
-		var buffer = BitConverter.GetBytes(value);
-		Write(BitConverter.ToInt32(buffer, 0));
+		Write(BitConverter.SingleToInt32Bits(value));
 	}
 	public ValueTask WriteAsync(float value, CancellationToken cancellationToken = default)
 	{
-		var buffer = BitConverter.GetBytes(value);
-		return WriteAsync(BitConverter.ToInt32(buffer, 0), cancellationToken);
+		return WriteAsync(BitConverter.SingleToInt32Bits(value), cancellationToken);
 	}
 
 	public void Write(double value)
 	{
-		var buffer = BitConverter.GetBytes(value);
-		Write(BitConverter.ToInt64(buffer, 0));
+		Write(BitConverter.DoubleToInt64Bits(value));
 	}
 	public ValueTask WriteAsync(double value, CancellationToken cancellationToken = default)
 	{
-		var buffer = BitConverter.GetBytes(value);
-		return WriteAsync(BitConverter.ToInt64(buffer, 0), cancellationToken);
+		return WriteAsync(BitConverter.DoubleToInt64Bits(value), cancellationToken);
 	}
 
 	public void Write(decimal value, int type, int scale)
@@ -715,11 +1068,16 @@ sealed class XdrReaderWriter : IXdrReader, IXdrWriter
 
 	public void Write(bool value)
 	{
-		WriteOpaque(TypeEncoder.EncodeBoolean(value));
+		Span<byte> buffer = stackalloc byte[1];
+		TypeEncoder.EncodeBoolean(value, buffer);
+		WriteOpaque(buffer);
 	}
 	public ValueTask WriteAsync(bool value, CancellationToken cancellationToken = default)
 	{
-		return WriteOpaqueAsync(TypeEncoder.EncodeBoolean(value), cancellationToken);
+		var rented = ArrayPool<byte>.Shared.Rent(1);
+		TypeEncoder.EncodeBoolean(value, rented.AsSpan());
+		var task = WriteOpaqueAsync(rented, 1, cancellationToken);
+		return ReturnAfter(task, rented);
 	}
 
 	public void Write(DateTime value)
@@ -735,7 +1093,8 @@ sealed class XdrReaderWriter : IXdrReader, IXdrWriter
 
 	public void Write(Guid value, int sqlType)
 	{
-		var bytes = TypeEncoder.EncodeGuid(value);
+		Span<byte> bytes = stackalloc byte[16];
+		TypeEncoder.EncodeGuid(value, bytes);
 		if (sqlType == IscCodes.SQL_VARYING)
 		{
 			WriteBuffer(bytes);
@@ -747,14 +1106,18 @@ sealed class XdrReaderWriter : IXdrReader, IXdrWriter
 	}
 	public ValueTask WriteAsync(Guid value, int sqlType, CancellationToken cancellationToken = default)
 	{
-		var bytes = TypeEncoder.EncodeGuid(value);
+		var rented = ArrayPool<byte>.Shared.Rent(16);
+		Span<byte> span = rented;
+		TypeEncoder.EncodeGuid(value, span);
 		if (sqlType == IscCodes.SQL_VARYING)
 		{
-			return WriteBufferAsync(bytes, cancellationToken);
+			var task = WriteBufferAsync(rented, 16, cancellationToken);
+			return ReturnAfter(task, rented);
 		}
 		else
 		{
-			return WriteOpaqueAsync(bytes, cancellationToken);
+			var task = WriteOpaqueAsync(rented, 16, cancellationToken);
+			return ReturnAfter(task, rented);
 		}
 	}
 
@@ -779,7 +1142,7 @@ sealed class XdrReaderWriter : IXdrReader, IXdrWriter
 
 	public void Write(BigInteger value)
 	{
-		WriteOpaqueAsync(TypeEncoder.EncodeInt128(value));
+		WriteOpaque(TypeEncoder.EncodeInt128(value));
 	}
 	public ValueTask WriteAsync(BigInteger value, CancellationToken cancellationToken = default)
 	{

--- a/src/FirebirdSql.Data.FirebirdClient/Common/Charset.cs
+++ b/src/FirebirdSql.Data.FirebirdClient/Common/Charset.cs
@@ -141,6 +141,11 @@ internal sealed class Charset
 		return Encoding.GetString(buffer);
 	}
 
+	public string GetString(ReadOnlySpan<byte> buffer)
+	{
+		return Encoding.GetString(buffer);
+	}
+
 	public string GetString(byte[] buffer, int index, int count)
 	{
 		return Encoding.GetString(buffer, index, count);

--- a/src/FirebirdSql.Data.FirebirdClient/Common/IscHelper.cs
+++ b/src/FirebirdSql.Data.FirebirdClient/Common/IscHelper.cs
@@ -232,4 +232,16 @@ internal static class IscHelper
 		}
 		return value;
 	}
+
+	public static long VaxInteger(ReadOnlySpan<byte> buffer, int index, int length)
+	{
+		var value = 0L;
+		var shift = 0;
+		var i = index;
+		while(--length >= 0) {
+			value += (buffer[i++] & 0xffL) << shift;
+			shift += 8;
+		}
+		return value;
+	}
 }

--- a/src/FirebirdSql.Data.FirebirdClient/Common/ParameterBuffer.cs
+++ b/src/FirebirdSql.Data.FirebirdClient/Common/ParameterBuffer.cs
@@ -63,7 +63,11 @@ internal abstract class ParameterBuffer
 		{
 			value = IPAddress.NetworkToHostOrder(value);
 		}
-		var buffer = BitConverter.GetBytes(value);
+		Span<byte> buffer = stackalloc byte[2];
+		if (!BitConverter.TryWriteBytes(buffer, value))
+		{
+			throw new InvalidOperationException("Failed to write Int16 bytes.");
+		}
 		Write(buffer);
 	}
 
@@ -73,7 +77,11 @@ internal abstract class ParameterBuffer
 		{
 			value = IPAddress.NetworkToHostOrder(value);
 		}
-		var buffer = BitConverter.GetBytes(value);
+		Span<byte> buffer = stackalloc byte[4];
+		if (!BitConverter.TryWriteBytes(buffer, value))
+		{
+			throw new InvalidOperationException("Failed to write Int32 bytes.");
+		}
 		Write(buffer);
 	}
 
@@ -83,13 +91,22 @@ internal abstract class ParameterBuffer
 		{
 			value = IPAddress.NetworkToHostOrder(value);
 		}
-		var buffer = BitConverter.GetBytes(value);
+		Span<byte> buffer = stackalloc byte[8];
+		if (!BitConverter.TryWriteBytes(buffer, value))
+		{
+			throw new InvalidOperationException("Failed to write Int64 bytes.");
+		}
 		Write(buffer);
 	}
 
 	protected void Write(byte[] buffer)
 	{
 		Write(buffer, 0, buffer.Length);
+	}
+
+	protected void Write(ReadOnlySpan<byte> buffer)
+	{
+		_data.AddRange(buffer);
 	}
 
 	protected void Write(byte[] buffer, int offset, int count)

--- a/src/FirebirdSql.Data.FirebirdClient/Common/TypeDecoder.cs
+++ b/src/FirebirdSql.Data.FirebirdClient/Common/TypeDecoder.cs
@@ -16,6 +16,7 @@
 //$Authors = Carlos Guzman Alvarez, Jiri Cincura (jiri@cincura.net)
 
 using System;
+using System.Buffers.Binary;
 using System.Net;
 using System.Numerics;
 using FirebirdSql.Data.Types;
@@ -98,23 +99,43 @@ internal static class TypeDecoder
 		return value[0] != 0;
 	}
 
+	public static bool DecodeBoolean(ReadOnlySpan<byte> value)
+	{
+		return value[0] != 0;
+	}
+
 	public static Guid DecodeGuid(byte[] value)
 	{
 		var a = IPAddress.HostToNetworkOrder(BitConverter.ToInt32(value, 0));
 		var b = IPAddress.HostToNetworkOrder(BitConverter.ToInt16(value, 4));
 		var c = IPAddress.HostToNetworkOrder(BitConverter.ToInt16(value, 6));
-		var d = new[] { value[8], value[9], value[10], value[11], value[12], value[13], value[14], value[15] };
-		return new Guid(a, b, c, d);
+		return new Guid(a, b, c, value[8], value[9], value[10], value[11], value[12], value[13], value[14], value[15]);
+	}
+
+	public static Guid DecodeGuidSpan(Span<byte> value)
+	{
+		var a = IPAddress.HostToNetworkOrder(BitConverter.ToInt32(value[..4]));
+		var b = IPAddress.HostToNetworkOrder(BitConverter.ToInt16(value[4..6]));
+		var c = IPAddress.HostToNetworkOrder(BitConverter.ToInt16(value[6..8]));
+		return new Guid(a, b, c, value[8], value[9], value[10], value[11], value[12], value[13], value[14], value[15]);
 	}
 
 	public static int DecodeInt32(byte[] value)
 	{
-		return IPAddress.HostToNetworkOrder(BitConverter.ToInt32(value, 0));
+		return BinaryPrimitives.ReadInt32BigEndian(value);
+	}
+
+	public static int DecodeInt32(Span<byte> value) {
+		return BinaryPrimitives.ReadInt32BigEndian(value);
 	}
 
 	public static long DecodeInt64(byte[] value)
 	{
-		return IPAddress.HostToNetworkOrder(BitConverter.ToInt64(value, 0));
+		return BinaryPrimitives.ReadInt64BigEndian(value);
+	}
+
+	public static long DecodeInt64(Span<byte> value) {
+		return BinaryPrimitives.ReadInt64BigEndian(value);
 	}
 
 	public static FbDecFloat DecodeDec16(byte[] value)


### PR DESCRIPTION
Decided to split up my previous pull request (https://github.com/FirebirdSQL/NETProvider/pull/1247) to multiple PRs due to it having set of changes too broad in my opinion. Ran tests as usual for fb3 server and embedded. Updated to current master branch state. Also decided to throw in reworked ring-buffer Queue's to be more large object friendly.

TLDR: Ellimination of most of the repeated allocations for intermediate conversions, also added inplace copy methods for I/O and reworked intermediate network buffers to use proper ring-buffer resizable arrays with unitary copying instead of per-byte queueing, massively boosting large objects throughput.

<details>
<summary>Practical benchmarks (3 int and 1 char100 columns, real I/O with fb3 server on localhost and nvme)</summary>

Master:

| Method                              | Rows   | Mean         | Error      | StdDev      | Median       | Gen0        | Gen1        | Allocated     |
|------------------------------------ |------- |-------------:|-----------:|------------:|-------------:|------------:|------------:|--------------:|
| SelectAndMap_Main_ReusedBufferAsync | 10     |     1.796 ms |  0.0649 ms |   0.1904 ms |     1.784 ms |           - |           - |     457.27 KB |
| SelectAndMap_Main_ReusedBufferAsync | 100    |     8.326 ms |  0.5724 ms |   1.5955 ms |     7.472 ms |           - |           - |    4502.13 KB |
| SelectAndMap_Main_ReusedBufferAsync | 1000   |    31.037 ms |  3.7512 ms |  10.8231 ms |    24.973 ms |   5000.0000 |   1000.0000 |   44985.72 KB |
| SelectAndMap_Main_ReusedBufferAsync | 10000  |   337.278 ms | 16.5461 ms |  48.7865 ms |   334.254 ms |  55000.0000 |  10000.0000 |  449543.01 KB |
| SelectAndMap_Main_ReusedBufferAsync | 100000 | 3,467.848 ms | 98.9785 ms | 288.7249 ms | 3,435.619 ms | 550000.0000 | 114000.0000 | 4494685.62 KB |


New (isolated from Rune opt (#1252)):

| Method                              | Rows   | Mean         | Error      | StdDev      | Median       | Gen0        | Gen1        | Allocated     |
|------------------------------------ |------- |-------------:|-----------:|------------:|-------------:|------------:|------------:|--------------:|
| SelectAndMap_Main_ReusedBufferAsync | 10     |     1.614 ms |  0.0500 ms |   0.1450 ms |     1.584 ms |           - |           - |        447 KB |
| SelectAndMap_Main_ReusedBufferAsync | 100    |     9.760 ms |  0.1127 ms |   0.0880 ms |     9.746 ms |           - |           - |    4411.49 KB |
| SelectAndMap_Main_ReusedBufferAsync | 1000   |    22.283 ms |  2.1941 ms |   6.1524 ms |    19.432 ms |   5000.0000 |   1000.0000 |   43999.39 KB |
| SelectAndMap_Main_ReusedBufferAsync | 10000  |   221.000 ms |  9.0103 ms |  26.1406 ms |   221.383 ms |  53000.0000 |  10000.0000 |  439534.85 KB |
| SelectAndMap_Main_ReusedBufferAsync | 100000 | 2,317.527 ms | 46.2359 ms | 108.0750 ms | 2,342.930 ms | 538000.0000 | 108000.0000 | 4394711.29 KB |


Combined with #1252:

| Method                              | Rows   | Mean         | Error        | StdDev       | Median       | Gen0       | Gen1      | Allocated    |
|------------------------------------ |------- |-------------:|-------------:|-------------:|-------------:|-----------:|----------:|-------------:|
| SelectAndMap_Main_ReusedBufferAsync | 10     |     471.8 us |     15.22 us |     43.68 us |     462.0 us |          - |         - |     43.98 KB |
| SelectAndMap_Main_ReusedBufferAsync | 100    |   1,638.7 us |     62.67 us |    182.81 us |   1,590.5 us |          - |         - |    383.96 KB |
| SelectAndMap_Main_ReusedBufferAsync | 1000   |  13,283.3 us |  2,299.73 us |  6,561.26 us |   9,672.6 us |          - |         - |   3785.55 KB |
| SelectAndMap_Main_ReusedBufferAsync | 10000  |  92,663.6 us |  2,673.87 us |  7,841.99 us |  91,372.1 us |  4000.0000 |         - |  37583.41 KB |
| SelectAndMap_Main_ReusedBufferAsync | 100000 | 897,179.0 us | 17,724.27 us | 24,846.95 us | 900,061.5 us | 45000.0000 | 5000.0000 | 375392.09 KB |


Perf (defaults):

| Method  | Job     | BuildConfiguration | DataType             | Count | Mean        | Error     | StdDev    | Ratio | RatioSD | Gen0    | Allocated | Alloc Ratio |
|-------- |-------- |------------------- |--------------------- |------ |------------:|----------:|----------:|------:|--------:|--------:|----------:|------------:|
| Execute | NuGet   | ReleaseNuGet       | bigint               | 100   | 19,426.6 us | 195.03 us | 172.89 us |  1.00 |    0.01 | 31.2500 | 290.31 KB |        1.00 |
| Execute | Project | Release            | bigint               | 100   | 19,731.2 us | 376.18 us | 369.46 us |  1.02 |    0.02 |       - | 192.32 KB |        0.66 |
|         |         |                    |                      |       |             |           |           |       |         |         |           |             |
| Fetch   | NuGet   | ReleaseNuGet       | bigint               | 100   |    461.9 us |   5.48 us |   5.12 us |  1.00 |    0.02 |  5.8594 |  52.02 KB |        1.00 |
| Fetch   | Project | Release            | bigint               | 100   |    449.6 us |   3.00 us |   2.81 us |  0.97 |    0.01 |  3.9063 |  39.03 KB |        0.75 |
|         |         |                    |                      |       |             |           |           |       |         |         |           |             |
| Execute | NuGet   | ReleaseNuGet       | varch(...) utf8 [30] | 100   | 19,592.1 us | 172.88 us | 144.36 us |  1.00 |    0.01 | 31.2500 | 294.24 KB |        1.00 |
| Execute | Project | Release            | varch(...) utf8 [30] | 100   | 19,419.8 us |  96.03 us |  80.19 us |  0.99 |    0.01 |       - | 194.64 KB |        0.66 |
|         |         |                    |                      |       |             |           |           |       |         |         |           |             |
| Fetch   | NuGet   | ReleaseNuGet       | varch(...) utf8 [30] | 100   |    466.2 us |   2.37 us |   2.22 us |  1.00 |    0.01 |  6.8359 |   55.9 KB |        1.00 |
| Fetch   | Project | Release            | varch(...) utf8 [30] | 100   |    458.4 us |   3.01 us |   2.67 us |  0.98 |    0.01 |  3.9063 |  39.77 KB |        0.71 |


</details>

Boost for large object I/O is significant. Benchmarks were performed without compression and encryption (typical for walled LAN / server sharing db with apps in single env). For small data types and writing operations, changes in practice are much smaller, but some difference in allocations can be observed still. Such an effect on performance is mostly due to ellimination of copies and ability for system to use packed operations (r/w with 64 bit ops instead of 8x8 bit ops) or even simd when dealing with the buffers, and also jit should be much happier with the new installment. For large blobs with the same mode boost can be even bigger with the bypass mode (less copies).