### PR TITLE
Improve CI workflow performance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           dotnet-version: 10.0.x
 
       - name: NuGet Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.nuget/packages
           key: nuget-${{ hashFiles('**/*.csproj', '**/Directory.Build.props', '**/Versions.props') }}
@@ -39,13 +39,13 @@ jobs:
         shell: powershell
 
       - name: Upload Build Output
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: build-output
           path: '.\\out\\'
 
       - name: Upload Test Binaries
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-binaries
           path: '.\\src\\**\\bin\\'
@@ -84,13 +84,13 @@ jobs:
           dotnet-version: 10.0.x
 
       - name: Download Test Binaries
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: test-binaries
           path: '.\\src\\'
 
       - name: Firebird Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: 'C:\firebird'
           key: firebird-${{ matrix.FIREBIRD_SELECTION }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,12 @@ jobs:
           name: test-binaries
           path: '.\\src\\'
 
+      - name: Firebird Cache
+        uses: actions/cache@v4
+        with:
+          path: 'C:\firebird'
+          key: firebird-${{ matrix.FIREBIRD_SELECTION }}
+
       - name: Tests
         run: |
           try {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,22 +7,24 @@ env:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
 
 jobs:
-  ci:
+  build:
     runs-on: windows-2025
-    strategy:
-      fail-fast: false
-      matrix:
-        FIREBIRD_SELECTION: [FB30, FB40, FB50]
-        TEST_SUITE: [Tests-FirebirdClient-Default-Compression-CryptRequired, Tests-FirebirdClient-Default-NoCompression-CryptRequired, Tests-FirebirdClient-Default-Compression-CryptDisabled, Tests-FirebirdClient-Default-NoCompression-CryptDisabled, Tests-FirebirdClient-Embedded, Tests-EFCore, Tests-EFCore-Functional, Tests-EF6]
-    timeout-minutes: 120
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v5
-        
+
       - name: .NET 10.0
         uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.0.x
+
+      - name: NuGet Cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: nuget-${{ hashFiles('**/*.csproj', '**/Directory.Build.props', '**/Versions.props') }}
+          restore-keys: nuget-
 
       - name: Build
         run: |
@@ -35,6 +37,42 @@ jobs:
             exit 1
           }
         shell: powershell
+
+      - name: Upload Build Output
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-output
+          path: '.\\out\\'
+
+      - name: Upload Test Binaries
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-binaries
+          path: '.\\src\\**\\bin\\'
+
+  test:
+    needs: build
+    runs-on: windows-2025
+    strategy:
+      fail-fast: false
+      matrix:
+        FIREBIRD_SELECTION: [FB30, FB40, FB50]
+        TEST_SUITE: [Tests-FirebirdClient-Default-Compression-CryptRequired, Tests-FirebirdClient-Default-NoCompression-CryptRequired, Tests-FirebirdClient-Default-Compression-CryptDisabled, Tests-FirebirdClient-Default-NoCompression-CryptDisabled, Tests-FirebirdClient-Embedded, Tests-EFCore, Tests-EFCore-Functional, Tests-EF6]
+    timeout-minutes: 120
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: .NET 10.0
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Download Test Binaries
+        uses: actions/download-artifact@v4
+        with:
+          name: test-binaries
+          path: '.\\src\\'
 
       - name: Tests
         run: |
@@ -49,9 +87,3 @@ jobs:
             exit 1
           }
         shell: powershell
-
-      - name: Publish Artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: 'ci_${{ matrix.TEST_SUITE }}_${{ matrix.FIREBIRD_SELECTION }}_${{ env.CONFIGURATION }}'
-          path: '.\\out\\'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,8 +56,23 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        FIREBIRD_SELECTION: [FB30, FB40, FB50]
-        TEST_SUITE: [Tests-FirebirdClient-Default-Compression-CryptRequired, Tests-FirebirdClient-Default-NoCompression-CryptRequired, Tests-FirebirdClient-Default-Compression-CryptDisabled, Tests-FirebirdClient-Default-NoCompression-CryptDisabled, Tests-FirebirdClient-Embedded, Tests-EFCore, Tests-EFCore-Functional, Tests-EF6]
+        include:
+          # Full coverage on FB50 (latest)
+          - { FIREBIRD_SELECTION: FB50, TEST_SUITE: Tests-FirebirdClient-Default-Compression-CryptRequired }
+          - { FIREBIRD_SELECTION: FB50, TEST_SUITE: Tests-FirebirdClient-Default-NoCompression-CryptRequired }
+          - { FIREBIRD_SELECTION: FB50, TEST_SUITE: Tests-FirebirdClient-Default-Compression-CryptDisabled }
+          - { FIREBIRD_SELECTION: FB50, TEST_SUITE: Tests-FirebirdClient-Default-NoCompression-CryptDisabled }
+          - { FIREBIRD_SELECTION: FB50, TEST_SUITE: Tests-FirebirdClient-Embedded }
+          - { FIREBIRD_SELECTION: FB50, TEST_SUITE: Tests-EFCore }
+          - { FIREBIRD_SELECTION: FB50, TEST_SUITE: Tests-EFCore-Functional }
+          - { FIREBIRD_SELECTION: FB50, TEST_SUITE: Tests-EF6 }
+          # Compatibility check on FB40
+          - { FIREBIRD_SELECTION: FB40, TEST_SUITE: Tests-FirebirdClient-All }
+          - { FIREBIRD_SELECTION: FB40, TEST_SUITE: Tests-EFCore }
+          - { FIREBIRD_SELECTION: FB40, TEST_SUITE: Tests-EF6 }
+          # Compatibility check on FB30
+          - { FIREBIRD_SELECTION: FB30, TEST_SUITE: Tests-FirebirdClient-All }
+          - { FIREBIRD_SELECTION: FB30, TEST_SUITE: Tests-EFCore }
     timeout-minutes: 120
     steps:
       - name: Checkout

--- a/build.ps1
+++ b/build.ps1
@@ -20,7 +20,6 @@ function Clean() {
 }
 
 function Build() {
-	dotnet clean "$baseDir\src\NETProvider.slnx" -c $Configuration -v m
 	dotnet build "$baseDir\src\NETProvider.slnx" -c $Configuration -p:ContinuousIntegrationBuild=true -v m
 }
 

--- a/tests.ps1
+++ b/tests.ps1
@@ -133,6 +133,13 @@ function Tests-FirebirdClient-Default-NoCompression-CryptDisabled() {
 function Tests-FirebirdClient-Embedded() {
 	Tests-FirebirdClient 'Embedded' $False 'Disabled'
 }
+function Tests-FirebirdClient-All() {
+	Tests-FirebirdClient-Default-Compression-CryptRequired
+	Tests-FirebirdClient-Default-NoCompression-CryptRequired
+	Tests-FirebirdClient-Default-Compression-CryptDisabled
+	Tests-FirebirdClient-Default-NoCompression-CryptDisabled
+	Tests-FirebirdClient-Embedded
+}
 function Tests-FirebirdClient($serverType, $compression, $wireCrypt) {
 	pushd $testsProviderDir
 	try {

--- a/tests.ps1
+++ b/tests.ps1
@@ -47,21 +47,36 @@ function Prepare() {
 	$selectedConfiguration = $FirebirdConfiguration[$FirebirdSelection]
 	$fbDownload = $selectedConfiguration.Download
 	$fbDownloadName = $fbDownload -Replace '.+/(.+)$','$1'
-	if (Test-Path $firebirdDir) {
-		rm -Force -Recurse $firebirdDir
+
+	if (Test-Path "$firebirdDir\firebird.exe") {
+		echo "Using cached Firebird from $firebirdDir"
 	}
-	mkdir $firebirdDir | Out-Null
+	else {
+		if (Test-Path $firebirdDir) {
+			rm -Force -Recurse $firebirdDir
+		}
+		mkdir $firebirdDir | Out-Null
+
+		pushd $firebirdDir
+		try {
+			echo "Downloading $fbDownload"
+			Invoke-RestMethod -Uri $fbDownload -OutFile $fbDownloadName
+			echo "Extracting $fbDownloadName"
+			7z x -bsp0 -bso0 $fbDownloadName
+			rm $fbDownloadName
+		}
+		finally {
+			popd
+		}
+	}
+
+	cp -Recurse -Force $firebirdDir\* $testsProviderDir
 
 	pushd $firebirdDir
 	try {
-		echo "Downloading $fbDownload"
-		Invoke-RestMethod -Uri $fbDownload -OutFile $fbDownloadName 
-		echo "Extracting $fbDownloadName"
-		7z x -bsp0 -bso0 $fbDownloadName
-		rm $fbDownloadName
-		cp -Recurse -Force .\* $testsProviderDir
-
-		ni firebird.log -ItemType File | Out-Null
+		if (-not (Test-Path firebird.log)) {
+			ni firebird.log -ItemType File | Out-Null
+		}
 
 		echo "Starting Firebird"
 		$process = Start-Process -FilePath $selectedConfiguration.Executable -ArgumentList $selectedConfiguration.Args -PassThru
@@ -88,7 +103,6 @@ function Cleanup() {
 		# give OS time to release all files
 		sleep -Milliseconds 100
 	}
-	rm -Force -Recurse $firebirdDir
 
 	Write-Host "=== END ==="
 }


### PR DESCRIPTION
## Problem

The CI workflow was taking over 40 minutes to complete, with 24 parallel jobs (3 Firebird versions ├ù 8 test suites) each independently building the entire solution, downloading Firebird, and running a single test suite.

## Changes

### 1. Remove unnecessary `dotnet clean` from `build.ps1`

On CI with a clean workspace, `dotnet clean` before `dotnet build` is redundant.

### 2. Split into build + test jobs with NuGet cache

- **Single build job** builds the solution once, uploads NuGet packages and test binaries as artifacts.
- **Test jobs** download pre-built binaries instead of rebuilding from scratch.
- **NuGet package caching** (`actions/cache`) speeds up the build step on subsequent runs.

This eliminates 23 redundant builds that were happening in the original 24-job matrix.

### 3. Cache Firebird server downloads

- Modified `Prepare()` in `tests.ps1` to skip download/extract when Firebird is already cached in `$firebirdDir`.
- Removed directory deletion from `Cleanup()` (CI runners are ephemeral, cleanup is unnecessary).
- Added `actions/cache` step keyed by Firebird version (`firebird-FB30`, `firebird-FB40`, `firebird-FB50`).

### 4. Add `Tests-FirebirdClient-All` grouped test suite

New function in `tests.ps1` that runs all 5 FirebirdClient test variants (4 compression/crypt combinations + embedded) in a single invocation. Used for older Firebird versions where individual granularity is less critical.

### 5. Trim CI matrix from 24 to 13 jobs

Replaced the full 3├ù8 cross-product matrix with a targeted `include` list:

| Firebird | Test Suites | Jobs |
|---|---|---|
| **FB50** (latest) | All 8 individual suites | 8 |
| **FB40** | FirebirdClient-All + EFCore + EF6 | 3 |
| **FB30** | FirebirdClient-All + EFCore | 2 |

Full test coverage is maintained on the latest Firebird version. Older versions get compatibility spot-checks using the grouped FirebirdClient suite.

### 6. Update GitHub Actions to Node.js 24-compatible versions

Updated actions that were triggering Node.js 20 deprecation warnings:

- `actions/cache` v4 ΓåÆ v5
- `actions/upload-artifact` v4 ΓåÆ v7
- `actions/download-artifact` v4 ΓåÆ v8

This resolves the warning:
> *Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/cache@v4, actions/upload-artifact@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026.*

## Results

Comparison between [previous run](https://github.com/fdcastel/NETProvider/actions/runs/23419273751) (before), [1st run](https://github.com/fdcastel/NETProvider/actions/runs/23420003587) (after, cold caches), and [2nd run](https://github.com/fdcastel/NETProvider/actions/runs/23420696481) (after, warm caches):

|  | Before | After (cold cache) | After (warm cache) |
|---|---|---|---|
| **Total jobs** | 24 | 14 (1 build + 13 test) | 14 (1 build + 13 test) |
| **Wall-clock time** | ~43 min | ~26 min | ~29 min |
| **Build job** | _(included in each job)_ | 3m 3s | 1m 38s |
| **Deprecation warnings** | Yes (Node.js 20) | Yes (Node.js 20) | None |

### Job timing breakdown

| Job | 1st run (cold cache) | 2nd run (warm cache) |
|---|---|---|
| build | 3m 3s | 1m 38s |
| test (FB50, FirebirdClient Compression CryptRequired) | 7m 49s | 4m 50s |
| test (FB50, FirebirdClient Compression CryptDisabled) | 6m 32s | 6m 29s |
| test (FB50, FirebirdClient NoCompression CryptRequired) | 5m 38s | 5m 25s |
| test (FB50, FirebirdClient NoCompression CryptDisabled) | 5m 25s | 5m 46s |
| test (FB50, FirebirdClient Embedded) | 3m 46s | 6m 2s |
| test (FB50, EFCore) | 2m 11s | 1m 26s |
| test (FB50, EFCore-Functional) | 1m 6s | 1m 7s |
| test (FB50, EF6) | 1m 2s | 1m 2s |
| test (FB40, FirebirdClient-All) | 21m 16s | 26m 21s |
| test (FB40, EFCore) | 1m 28s | 1m 15s |
| test (FB40, EF6) | 1m 7s | 1m 5s |
| test (FB30, FirebirdClient-All) | 22m 47s | 21m 43s |
| test (FB30, EFCore) | 1m 23s | 1m 22s |

> **Note:** The build job improved from 3m 3s to 1m 38s on the 2nd run thanks to NuGet cache. Firebird cache saves download/extraction time within each test job. Wall-clock time variance between runs is normal due to runner availability and test execution variability.
