### PR TITLE
GetIndexesQuery: Exclude expression indexes at the database level. Fix #1188.

### DIFF
--- a/src/FirebirdSql.EntityFrameworkCore.Firebird.Tests/Scaffolding/ScaffoldingTests.cs
+++ b/src/FirebirdSql.EntityFrameworkCore.Firebird.Tests/Scaffolding/ScaffoldingTests.cs
@@ -107,6 +107,54 @@ public class ScaffoldingTests : EntityFrameworkCoreTestsBase
 		Assert.That(column.StoreType, Is.EqualTo(dataType));
 	}
 
+	[Test]
+	public async Task ExpressionIndexDoesNotBreakScaffolding()
+	{
+		var tableName = "TEST_EXPR_IDX";
+
+		using var commandTable = Connection.CreateCommand();
+		commandTable.CommandText = $"recreate table {tableName} (ID INTEGER NOT NULL, DATA VARCHAR(100))";
+		await commandTable.ExecuteNonQueryAsync();
+
+		using var commandIndex = Connection.CreateCommand();
+		commandIndex.CommandText = $"create index IDX_EXPR on {tableName} computed by (upper(DATA))";
+		await commandIndex.ExecuteNonQueryAsync();
+
+		var modelFactory = GetModelFactory();
+		var model = modelFactory.Create(Connection.ConnectionString, new DatabaseModelFactoryOptions(new string[] { tableName }));
+		var table = model.Tables.Single(x => x.Name == tableName);
+
+		Assert.That(table.Indexes, Has.None.Matches<Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseIndex>(x => x.Name == "IDX_EXPR"));
+	}
+
+	[Test]
+	public async Task RegularIndexScaffoldedAlongsideExpressionIndex()
+	{
+		var tableName = "TEST_MIX_IDX";
+
+		using var commandTable = Connection.CreateCommand();
+		commandTable.CommandText = $"recreate table {tableName} (ID INTEGER NOT NULL, DATA VARCHAR(100))";
+		await commandTable.ExecuteNonQueryAsync();
+
+		using var commandRegularIndex = Connection.CreateCommand();
+		commandRegularIndex.CommandText = $"create index IDX_REGULAR on {tableName} (DATA)";
+		await commandRegularIndex.ExecuteNonQueryAsync();
+
+		using var commandExprIndex = Connection.CreateCommand();
+		commandExprIndex.CommandText = $"create index IDX_EXPR_MIX on {tableName} computed by (upper(DATA))";
+		await commandExprIndex.ExecuteNonQueryAsync();
+
+		var modelFactory = GetModelFactory();
+		var model = modelFactory.Create(Connection.ConnectionString, new DatabaseModelFactoryOptions(new string[] { tableName }));
+		var table = model.Tables.Single(x => x.Name == tableName);
+
+		Assert.Multiple(() =>
+		{
+			Assert.That(table.Indexes, Has.Some.Matches<Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseIndex>(x => x.Name == "IDX_REGULAR"));
+			Assert.That(table.Indexes, Has.None.Matches<Microsoft.EntityFrameworkCore.Scaffolding.Metadata.DatabaseIndex>(x => x.Name == "IDX_EXPR_MIX"));
+		});
+	}
+
 	static IDatabaseModelFactory GetModelFactory()
 	{
 		return new FbDatabaseModelFactory();

--- a/src/FirebirdSql.EntityFrameworkCore.Firebird/Scaffolding/Internal/FbDatabaseModelFactory.cs
+++ b/src/FirebirdSql.EntityFrameworkCore.Firebird/Scaffolding/Internal/FbDatabaseModelFactory.cs
@@ -319,6 +319,7 @@ public class FbDatabaseModelFactory : DatabaseModelFactory
                LEFT JOIN rdb$relation_constraints rc on rc.rdb$index_name = I.rdb$index_name and rc.rdb$constraint_type = null
               WHERE
                trim(i.rdb$relation_name) = '{0}'
+               AND i.RDB$EXPRESSION_SOURCE IS NULL
               GROUP BY
                INDEX_NAME, IS_UNIQUE, IS_DESC ;";
 
@@ -337,6 +338,12 @@ public class FbDatabaseModelFactory : DatabaseModelFactory
 				{
 					while (reader.Read())
 					{
+						var columns = reader.IsDBNull(3) ? string.Empty : reader.GetString(3);
+						if (string.IsNullOrEmpty(columns))
+						{
+							continue;
+						}
+
 						var index = new DatabaseIndex
 						{
 							Table = table,
@@ -344,7 +351,7 @@ public class FbDatabaseModelFactory : DatabaseModelFactory
 							IsUnique = reader.GetBoolean(1),
 						};
 
-						foreach (var column in reader.GetString(3).Split(','))
+						foreach (var column in columns.Split(','))
 						{
 							index.Columns.Add(table.Columns.Single(y => y.Name == column.Trim()));
 						}


### PR DESCRIPTION
`FbDatabaseModelFactory.GetIndexes` uses `table.Columns.Single(...)` to look up index columns by name. Expression-based indexes (e.g., `COMPUTED BY (upper(col))`) don't have real column entries in `RDB$INDEX_SEGMENTS` — their segment names don't match any table column — causing `Single()` to throw "Sequence contains no matching element".

### Changes

**FbDatabaseModelFactory.cs**:
1. **SQL query** — Added `AND i.RDB$EXPRESSION_SOURCE IS NULL` to `GetIndexesQuery` to exclude expression indexes at the database level. Expression indexes can't be meaningfully represented in EF Core's scaffolded model anyway.
2. **Code safety** — Added a null/empty check for the COLUMNS value before iterating, using `reader.IsDBNull(3)` and `string.IsNullOrEmpty()` to skip indexes with no segments gracefully.

**ScaffoldingTests.cs**:
- `ExpressionIndexDoesNotBreakScaffolding` — Creates a table with an expression index and verifies scaffolding completes without throwing, and the expression index is excluded from the model.
- `RegularIndexScaffoldedAlongsideExpressionIndex` — Creates a table with both a regular and an expression index, verifying the regular index is scaffolded correctly while the expression index is excluded.
